### PR TITLE
Migration of Determinent() from Laplace's method to Gaussian elimination

### DIFF
--- a/Examples/Mathematics/Program.cs
+++ b/Examples/Mathematics/Program.cs
@@ -326,7 +326,7 @@ namespace Mathematics
 			ConsoleWrite(Matrix<double>.ReducedEchelon(M));
 
 			// Matrix Determinant
-			Console.WriteLine("    determinent(M): " + string.Format("{0:0.00}", Matrix<double>.Determinent(M)));
+			Console.WriteLine("    determinant(M): " + string.Format("{0:0.00}", Matrix<double>.Determinant(M)));
 			Console.WriteLine();
 
 			// Matrix-Vector Multiplication

--- a/Sources/Towel/Mathematics/Matrix.cs
+++ b/Sources/Towel/Mathematics/Matrix.cs
@@ -345,10 +345,12 @@ namespace Towel.Mathematics
 
 		#region SwapRows
 
-		internal static void SwapRows(Matrix<T> matrix, int row1, int row2)
+		internal static void SwapRows(Matrix<T> matrix, int row1, int row2) =>
+			SwapRows(matrix, row1, row2, 0, matrix.Columns - 1);
+
+		internal static void SwapRows(Matrix<T> matrix, int row1, int row2, int columnStart, int columnEnd)
 		{
-			int columns = matrix.Columns;
-			for (int i = 0; i < columns; i++)
+			for (int i = columnStart; i <= columnEnd; i++)
 			{
 				T temp = matrix.Get(row1, i);
 				matrix.Set(row1, i, matrix.Get(row2, i));
@@ -474,12 +476,6 @@ namespace Towel.Mathematics
 			}
 			var determinant = new MatrixElementFraction<T>(Constant<T>.One);
 
-			void SwapRows(Matrix<MatrixElementFraction<T>> A, int row1, int row2, int size)
-			{
-				for (int i = 0; i < size; i++)
-					(A[row1, i], A[row2, i]) = (A[row2, i], A[row1, i]);
-			}
-
 			var fractioned = new Matrix<MatrixElementFraction<T>>(src.Rows, src.Columns);
 			for (int x = 0; x < src.Rows; x++)
 			for (int y = 0; y < src.Columns; y++)
@@ -503,7 +499,7 @@ namespace Towel.Mathematics
 				}
 				if (pivotRow != i)
 				{
-					SwapRows(fractioned, i, pivotRow, n);
+					Matrix<MatrixElementFraction<T>>.SwapRows(fractioned, i, pivotRow, 0, n - 1);
 					determinant = Negation(determinant);
 				}
 

--- a/Sources/Towel/Mathematics/Matrix.cs
+++ b/Sources/Towel/Mathematics/Matrix.cs
@@ -390,166 +390,166 @@ namespace Towel.Mathematics
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		private sealed class MatrixElementFraction<T>
-        {
-            private T Numerator;
-            private T Denominator;
+		{
+			private T Numerator;
+			private T Denominator;
 
-            internal MatrixElementFraction(T value)
-            {
-                Numerator = value;
-                Denominator = Constant<T>.One;
-            }
+			internal MatrixElementFraction(T value)
+			{
+				Numerator = value;
+				Denominator = Constant<T>.One;
+			}
 
-            internal MatrixElementFraction(T num, T den)
-            {
-                Numerator = num;
-                Denominator = den;
-            }
+			internal MatrixElementFraction(T num, T den)
+			{
+				Numerator = num;
+				Denominator = den;
+			}
 
-            public T Value => Division(Numerator, Denominator);
+			public T Value => Division(Numerator, Denominator);
 
 			// a / b + c / d = (a * d + b * c) / (b * d)
-            public static MatrixElementFraction<T> operator +(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
-                => new MatrixElementFraction<T>(Addition(
-                    Multiplication(a.Numerator, b.Denominator),
-                    Multiplication(a.Denominator, b.Numerator)
-                ), Multiplication(a.Denominator, b.Denominator));
+			public static MatrixElementFraction<T> operator +(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
+				=> new MatrixElementFraction<T>(Addition(
+					Multiplication(a.Numerator, b.Denominator),
+					Multiplication(a.Denominator, b.Numerator)
+				), Multiplication(a.Denominator, b.Denominator));
 
-            public static MatrixElementFraction<T> operator *(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
-                => new MatrixElementFraction<T>(Multiplication(a.Numerator, b.Numerator), Multiplication(a.Denominator, b.Denominator));
+			public static MatrixElementFraction<T> operator *(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
+				=> new MatrixElementFraction<T>(Multiplication(a.Numerator, b.Numerator), Multiplication(a.Denominator, b.Denominator));
 
-            public static MatrixElementFraction<T> operator -(MatrixElementFraction<T> a)
-                => new MatrixElementFraction<T>(Multiplication(a.Numerator, Constant<T>.NegativeOne), a.Denominator);
+			public static MatrixElementFraction<T> operator -(MatrixElementFraction<T> a)
+				=> new MatrixElementFraction<T>(Multiplication(a.Numerator, Constant<T>.NegativeOne), a.Denominator);
 
-            public static MatrixElementFraction<T> operator -(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
-                => a + (-b);
+			public static MatrixElementFraction<T> operator -(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
+				=> a + (-b);
 
 			// a / b / (d / c) = (a * c) / (b * d)
-            public static MatrixElementFraction<T> operator /(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
-                => new MatrixElementFraction<T>(Multiplication(a.Numerator, b.Denominator), Multiplication(a.Denominator, b.Numerator));
+			public static MatrixElementFraction<T> operator /(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
+				=> new MatrixElementFraction<T>(Multiplication(a.Numerator, b.Denominator), Multiplication(a.Denominator, b.Numerator));
 
-            public static bool operator <(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
-            {
-                var c = Multiplication(a.Numerator, b.Denominator);
-                var d = Multiplication(b.Numerator, a.Denominator);
-                if (IsPositive(Multiplication(a.Denominator, b.Denominator)))
-                    return LessThan(c, d);
-                else
-                    return !LessThan(c, d);
-            }
+			public static bool operator <(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
+			{
+				var c = Multiplication(a.Numerator, b.Denominator);
+				var d = Multiplication(b.Numerator, a.Denominator);
+				if (IsPositive(Multiplication(a.Denominator, b.Denominator)))
+					return LessThan(c, d);
+				else
+					return !LessThan(c, d);
+			}
 
-            public static bool operator ==(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
-                => Compare.Default(a.Numerator, b.Numerator) == CompareResult.Equal &&
-                   Compare.Default(a.Denominator, b.Denominator) == CompareResult.Equal;
-            public static bool operator !=(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
-                => !(a == b);
+			public static bool operator ==(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
+				=> Compare.Default(a.Numerator, b.Numerator) == CompareResult.Equal &&
+				   Compare.Default(a.Denominator, b.Denominator) == CompareResult.Equal;
+			public static bool operator !=(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
+				=> !(a == b);
 
-            public static bool operator >(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
-                => a >= b && !(a == b);
+			public static bool operator >(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
+				=> a >= b && !(a == b);
 
-            public static bool operator >=(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
-                => !(a < b);
+			public static bool operator >=(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
+				=> !(a < b);
 
-            public static bool operator <=(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
-                => a < b || a == b;
+			public static bool operator <=(MatrixElementFraction<T> a, MatrixElementFraction<T> b)
+				=> a < b || a == b;
 
-            public static explicit operator MatrixElementFraction<T>(int val)
-                => new MatrixElementFraction<T>(Convert<int, T>(val));
+			public static explicit operator MatrixElementFraction<T>(int val)
+				=> new MatrixElementFraction<T>(Convert<int, T>(val));
 
-            public MatrixElementFraction<T> Abs()
-                => new MatrixElementFraction<T>(AbsoluteValue(Numerator), AbsoluteValue(Denominator));
+			public MatrixElementFraction<T> Abs()
+				=> new MatrixElementFraction<T>(AbsoluteValue(Numerator), AbsoluteValue(Denominator));
 
-            public bool IsDividedByZero => Compare.Default(Denominator, Constant<T>.Zero) == CompareResult.Equal;
-        }
+			public bool IsDividedByZero => Compare.Default(Denominator, Constant<T>.Zero) == CompareResult.Equal;
+		}
 #endregion
 
 		/// <summary>
 		/// Reference: https://codereview.stackexchange.com/questions/204135/determinant-using-gauss-elimination
 		/// </summary>
 		internal static T GetDeterminantGaussian(Matrix<T> src, int n)
-        {
-            if (n == 1)
-            {
-                return src.Get(0, 0);
-            }
-            var determinent = new MatrixElementFraction<T>(Constant<T>.One);
+		{
+			if (n == 1)
+			{
+				return src.Get(0, 0);
+			}
+			var determinent = new MatrixElementFraction<T>(Constant<T>.One);
 
-            void SwapRows(Matrix<MatrixElementFraction<T>> A, int row1, int row2, int size)
-            {
-                for (int i = 0; i < size; i++)
-                    (A[row1, i], A[row2, i]) = (A[row2, i], A[row1, i]);
-            }
+			void SwapRows(Matrix<MatrixElementFraction<T>> A, int row1, int row2, int size)
+			{
+				for (int i = 0; i < size; i++)
+					(A[row1, i], A[row2, i]) = (A[row2, i], A[row1, i]);
+			}
 
-            var fractioned = new Matrix<MatrixElementFraction<T>>(src.Rows, src.Columns);
+			var fractioned = new Matrix<MatrixElementFraction<T>>(src.Rows, src.Columns);
 			for (int x = 0; x < src.Rows; x++)
-            for (int y = 0; y < src.Columns; y++)
-                fractioned[x, y] = new MatrixElementFraction<T>(src[x, y]);
+			for (int y = 0; y < src.Columns; y++)
+				fractioned[x, y] = new MatrixElementFraction<T>(src[x, y]);
 			
-            for (int i = 0; i < n; i++)
-            {
-                var pivotElement = fractioned[i, i];
-                var pivotRow = i;
-                for (int row = i + 1; row < n; ++row)
-                {
-                    if (fractioned[row, i].Abs() > pivotElement.Abs())
-                    {
-                        pivotElement = fractioned[row, i];
-                        pivotRow = row;
-                    }
-                }
-                if (pivotElement.Equals(Constant<T>.Zero))
-                {
-                    return Constant<T>.Zero;
-                }
-                if (pivotRow != i)
-                {
-                    SwapRows(fractioned, i, pivotRow, n);
-                    determinent = Negation(determinent);
-                }
+			for (int i = 0; i < n; i++)
+			{
+				var pivotElement = fractioned[i, i];
+				var pivotRow = i;
+				for (int row = i + 1; row < n; ++row)
+				{
+					if (fractioned[row, i].Abs() > pivotElement.Abs())
+					{
+						pivotElement = fractioned[row, i];
+						pivotRow = row;
+					}
+				}
+				if (pivotElement.Equals(Constant<T>.Zero))
+				{
+					return Constant<T>.Zero;
+				}
+				if (pivotRow != i)
+				{
+					SwapRows(fractioned, i, pivotRow, n);
+					determinent = Negation(determinent);
+				}
 
-                determinent = determinent * pivotElement;
+				determinent = determinent * pivotElement;
 
-                for (int row = i + 1; row < n; ++row)
-                {
-                    for (int col = i + 1; col < n; ++col)
-                    {
+				for (int row = i + 1; row < n; ++row)
+				{
+					for (int col = i + 1; col < n; ++col)
+					{
 						// from reference: matrix[row][col] -= matrix[row][i] * matrix[i][col] / pivotElement;
-                        fractioned[row, col] =
-                            Subtraction(fractioned[row, col], 
-                                Division(Multiplication(fractioned[row, i], fractioned[i, col]), pivotElement));
-                    }
-                }
+						fractioned[row, col] =
+							Subtraction(fractioned[row, col], 
+								Division(Multiplication(fractioned[row, i], fractioned[i, col]), pivotElement));
+					}
+				}
 			}
 
 			// TODO: should we return zero if determinent's denominator is zero?
-            return determinent.IsDividedByZero ? Constant<T>.Zero : determinent.Value;
-        }
+			return determinent.IsDividedByZero ? Constant<T>.Zero : determinent.Value;
+		}
 
 
 		#endregion
 
 		#region GetDeterminant Laplace method
-        internal static T GetDeterminantLaplace(Matrix<T> a, int n)
-        {
-            T determinent = Constant<T>.Zero;
-            if (n == 1)
-            {
-                return a.Get(0, 0);
-            }
-            Matrix<T> temp = new Matrix<T>(n, n);
-            T sign = Constant<T>.One;
-            for (int f = 0; f < n; f++)
-            {
-                GetCofactor(a, temp, 0, f, n);
-                determinent =
-                    Addition(determinent,
-                        Multiplication(sign,
-                            Multiplication(a.Get(0, f),
-                                GetDeterminantGaussian(temp, n - 1))));
-                sign = Negation(sign);
-            }
-            return determinent;
-        }
+		internal static T GetDeterminantLaplace(Matrix<T> a, int n)
+		{
+			T determinent = Constant<T>.Zero;
+			if (n == 1)
+			{
+				return a.Get(0, 0);
+			}
+			Matrix<T> temp = new Matrix<T>(n, n);
+			T sign = Constant<T>.One;
+			for (int f = 0; f < n; f++)
+			{
+				GetCofactor(a, temp, 0, f, n);
+				determinent =
+					Addition(determinent,
+						Multiplication(sign,
+							Multiplication(a.Get(0, f),
+								GetDeterminantGaussian(temp, n - 1))));
+				sign = Negation(sign);
+			}
+			return determinent;
+		}
 		#endregion
 
 		#region IsSymetric
@@ -1236,82 +1236,82 @@ namespace Towel.Mathematics
 		/// <returns>The computed determinent.</returns>
 		[Obsolete("Use DeterminentGaussian or DeterminentLaplace instead")]
 		public static T Determinent(Matrix<T> a)
-        {
-            return DeterminentLaplace(a);
+		{
+			return DeterminentLaplace(a);
 
-            #region Old Version
+			#region Old Version
 
-            //if (a is null)
-            //{
-            //    throw new ArgumentNullException(nameof(a));
-            //}
-            //if (!a.IsSquare)
-            //{
-            //    throw new MathematicsException("Argument invalid !(" + nameof(a) + "." + nameof(a.IsSquare) + ")");
-            //}
-            //T determinant = Constant<T>.One;
-            //Matrix<T> rref = a.Clone();
-            //int a_rows = a._rows;
-            //for (int i = 0; i < a_rows; i++)
-            //{
-            //    if (Compute.Equal(rref[i, i], Constant<T>.Zero))
-            //    {
-            //        for (int j = i + 1; j < rref.Rows; j++)
-            //        {
-            //            if (Compute.NotEqual(rref.Get(j, i), Constant<T>.Zero))
-            //            {
-            //                SwapRows(rref, i, j);
-            //                determinant = Compute.Multiply(determinant, Constant<T>.NegativeOne);
-            //            }
-            //        }
-            //    }
-            //    determinant = Compute.Multiply(determinant, rref.Get(i, i));
-            //    T temp_rowMultiplication = Compute.Divide(Constant<T>.One, rref.Get(i, i));
-            //    RowMultiplication(rref, i, temp_rowMultiplication);
-            //    for (int j = i + 1; j < rref.Rows; j++)
-            //    {
-            //        T scalar = Compute.Negate(rref.Get(j, i));
-            //        RowAddition(rref, j, i, scalar);
+			//if (a is null)
+			//{
+			//	throw new ArgumentNullException(nameof(a));
+			//}
+			//if (!a.IsSquare)
+			//{
+			//	throw new MathematicsException("Argument invalid !(" + nameof(a) + "." + nameof(a.IsSquare) + ")");
+			//}
+			//T determinant = Constant<T>.One;
+			//Matrix<T> rref = a.Clone();
+			//int a_rows = a._rows;
+			//for (int i = 0; i < a_rows; i++)
+			//{
+			//	if (Compute.Equal(rref[i, i], Constant<T>.Zero))
+			//	{
+			//		for (int j = i + 1; j < rref.Rows; j++)
+			//		{
+			//			if (Compute.NotEqual(rref.Get(j, i), Constant<T>.Zero))
+			//			{
+			//				SwapRows(rref, i, j);
+			//				determinant = Compute.Multiply(determinant, Constant<T>.NegativeOne);
+			//			}
+			//		}
+			//	}
+			//	determinant = Compute.Multiply(determinant, rref.Get(i, i));
+			//	T temp_rowMultiplication = Compute.Divide(Constant<T>.One, rref.Get(i, i));
+			//	RowMultiplication(rref, i, temp_rowMultiplication);
+			//	for (int j = i + 1; j < rref.Rows; j++)
+			//	{
+			//		T scalar = Compute.Negate(rref.Get(j, i));
+			//		RowAddition(rref, j, i, scalar);
 
-            //    }
-            //    for (int j = i - 1; j >= 0; j--)
-            //    {
-            //        T scalar = Compute.Negate(rref.Get(j, i));
-            //        RowAddition(rref, j, i, scalar);
+			//	}
+			//	for (int j = i - 1; j >= 0; j--)
+			//	{
+			//		T scalar = Compute.Negate(rref.Get(j, i));
+			//		RowAddition(rref, j, i, scalar);
 
-            //    }
-            //}
-            //return determinant;
+			//	}
+			//}
+			//return determinant;
 
-            #endregion
+			#endregion
 
-        }
-
-        /// <summary>Computes the determinent of a square matrix via Gaussian elimination.</summary>
-        /// <param name="a">The matrix to compute the determinent of.</param>
-        /// <returns>The computed determinent.</returns>
-		public static T DeterminentGaussian(Matrix<T> a)
-        {
-            _ = a ?? throw new ArgumentNullException(nameof(a));
-            if (!a.IsSquare)
-            {
-                throw new MathematicsException("Argument invalid !(" + nameof(a) + "." + nameof(a.IsSquare) + ")");
-            }
-            return GetDeterminantGaussian(a, a.Rows);
 		}
 
-        /// <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
-        /// <param name="a">The matrix to compute the determinent of.</param>
-        /// <returns>The computed determinent.</returns>
+		/// <summary>Computes the determinent of a square matrix via Gaussian elimination.</summary>
+		/// <param name="a">The matrix to compute the determinent of.</param>
+		/// <returns>The computed determinent.</returns>
+		public static T DeterminentGaussian(Matrix<T> a)
+		{
+			_ = a ?? throw new ArgumentNullException(nameof(a));
+			if (!a.IsSquare)
+			{
+				throw new MathematicsException("Argument invalid !(" + nameof(a) + "." + nameof(a.IsSquare) + ")");
+			}
+			return GetDeterminantGaussian(a, a.Rows);
+		}
+
+		/// <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
+		/// <param name="a">The matrix to compute the determinent of.</param>
+		/// <returns>The computed determinent.</returns>
 		public static T DeterminentLaplace(Matrix<T> a)
-        {
-            _ = a ?? throw new ArgumentNullException(nameof(a));
-            if (!a.IsSquare)
-            {
-                throw new MathematicsException("Argument invalid !(" + nameof(a) + "." + nameof(a.IsSquare) + ")");
-            }
-            return GetDeterminantLaplace(a, a.Rows);
-        }
+		{
+			_ = a ?? throw new ArgumentNullException(nameof(a));
+			if (!a.IsSquare)
+			{
+				throw new MathematicsException("Argument invalid !(" + nameof(a) + "." + nameof(a.IsSquare) + ")");
+			}
+			return GetDeterminantLaplace(a, a.Rows);
+		}
 
 		/// <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
 		/// <returns>The computed determinent.</returns>
@@ -1321,19 +1321,19 @@ namespace Towel.Mathematics
 			return DeterminentLaplace(this);
 		}
 
-        /// <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
-        /// <returns>The computed determinent.</returns>
-        public T DeterminentLaplace()
-        {
-            return DeterminentLaplace(this);
-        }
+		/// <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
+		/// <returns>The computed determinent.</returns>
+		public T DeterminentLaplace()
+		{
+			return DeterminentLaplace(this);
+		}
 
-        /// <summary>Computes the determinent of a square matrix via Gaussian elimination.</summary>
-        /// <returns>The computed determinent.</returns>
-        public T DeterminentGaussian()
-        {
-            return DeterminentGaussian(this);
-        }
+		/// <summary>Computes the determinent of a square matrix via Gaussian elimination.</summary>
+		/// <returns>The computed determinent.</returns>
+		public T DeterminentGaussian()
+		{
+			return DeterminentGaussian(this);
+		}
 
 		#endregion
 

--- a/Sources/Towel/Mathematics/Matrix.cs
+++ b/Sources/Towel/Mathematics/Matrix.cs
@@ -472,7 +472,7 @@ namespace Towel.Mathematics
 			{
 				return src.Get(0, 0);
 			}
-			var determinent = new MatrixElementFraction<T>(Constant<T>.One);
+			var determinant = new MatrixElementFraction<T>(Constant<T>.One);
 
 			void SwapRows(Matrix<MatrixElementFraction<T>> A, int row1, int row2, int size)
 			{
@@ -504,10 +504,10 @@ namespace Towel.Mathematics
 				if (pivotRow != i)
 				{
 					SwapRows(fractioned, i, pivotRow, n);
-					determinent = Negation(determinent);
+					determinant = Negation(determinant);
 				}
 
-				determinent = determinent * pivotElement;
+				determinant = determinant * pivotElement;
 
 				for (int row = i + 1; row < n; ++row)
 				{
@@ -521,8 +521,8 @@ namespace Towel.Mathematics
 				}
 			}
 
-			// TODO: should we return zero if determinent's denominator is zero?
-			return determinent.IsDividedByZero ? Constant<T>.Zero : determinent.Value;
+			// TODO: should we return zero if determinant's denominator is zero?
+			return determinant.IsDividedByZero ? Constant<T>.Zero : determinant.Value;
 		}
 
 
@@ -531,7 +531,7 @@ namespace Towel.Mathematics
 		#region GetDeterminant Laplace method
 		internal static T GetDeterminantLaplace(Matrix<T> a, int n)
 		{
-			T determinent = Constant<T>.Zero;
+			T determinant = Constant<T>.Zero;
 			if (n == 1)
 			{
 				return a.Get(0, 0);
@@ -541,14 +541,14 @@ namespace Towel.Mathematics
 			for (int f = 0; f < n; f++)
 			{
 				GetCofactor(a, temp, 0, f, n);
-				determinent =
-					Addition(determinent,
+				determinant =
+					Addition(determinant,
 						Multiplication(sign,
 							Multiplication(a.Get(0, f),
 								GetDeterminantLaplace(temp, n - 1))));
 				sign = Negation(sign);
 			}
-			return determinent;
+			return determinant;
 		}
 		#endregion
 
@@ -1229,15 +1229,14 @@ namespace Towel.Mathematics
 
 		#endregion
 
-		#region Determinent
+		#region Determinant
 
-		/// <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
-		/// <param name="a">The matrix to compute the determinent of.</param>
-		/// <returns>The computed determinent.</returns>
-		[Obsolete("Use DeterminentGaussian or DeterminentLaplace instead")]
-		public static T Determinent(Matrix<T> a)
+		/// <summary>Computes the determinant of a square matrix.</summary>
+		/// <param name="a">The matrix to compute the determinant of.</param>
+		/// <returns>The computed determinant.</returns>
+		public static T Determinant(Matrix<T> a)
 		{
-			return DeterminentLaplace(a);
+			return DeterminantGaussian(a);
 
 			#region Old Version
 
@@ -1287,10 +1286,10 @@ namespace Towel.Mathematics
 
 		}
 
-		/// <summary>Computes the determinent of a square matrix via Gaussian elimination.</summary>
-		/// <param name="a">The matrix to compute the determinent of.</param>
-		/// <returns>The computed determinent.</returns>
-		public static T DeterminentGaussian(Matrix<T> a)
+		/// <summary>Computes the determinant of a square matrix via Gaussian elimination.</summary>
+		/// <param name="a">The matrix to compute the determinant of.</param>
+		/// <returns>The computed determinant.</returns>
+		public static T DeterminantGaussian(Matrix<T> a)
 		{
 			_ = a ?? throw new ArgumentNullException(nameof(a));
 			if (!a.IsSquare)
@@ -1300,10 +1299,10 @@ namespace Towel.Mathematics
 			return GetDeterminantGaussian(a, a.Rows);
 		}
 
-		/// <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
-		/// <param name="a">The matrix to compute the determinent of.</param>
-		/// <returns>The computed determinent.</returns>
-		public static T DeterminentLaplace(Matrix<T> a)
+		/// <summary>Computes the determinant of a square matrix via Laplace's method.</summary>
+		/// <param name="a">The matrix to compute the determinant of.</param>
+		/// <returns>The computed determinant.</returns>
+		public static T DeterminantLaplace(Matrix<T> a)
 		{
 			_ = a ?? throw new ArgumentNullException(nameof(a));
 			if (!a.IsSquare)
@@ -1313,26 +1312,25 @@ namespace Towel.Mathematics
 			return GetDeterminantLaplace(a, a.Rows);
 		}
 
-		/// <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
-		/// <returns>The computed determinent.</returns>
-		[Obsolete("Use DeterminentGaussian or DeterminentLaplace instead")]
-		public T Determinent()
+		/// <summary>Computes the determinant of a square matrix.</summary>
+		/// <returns>The computed determinant.</returns>
+		public T Determinant()
 		{
-			return DeterminentLaplace(this);
+			return DeterminantGaussian(this);
 		}
 
-		/// <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
-		/// <returns>The computed determinent.</returns>
-		public T DeterminentLaplace()
+		/// <summary>Computes the determinant of a square matrix via Laplace's method.</summary>
+		/// <returns>The computed determinant.</returns>
+		public T DeterminantLaplace()
 		{
-			return DeterminentLaplace(this);
+			return DeterminantLaplace(this);
 		}
 
-		/// <summary>Computes the determinent of a square matrix via Gaussian elimination.</summary>
-		/// <returns>The computed determinent.</returns>
-		public T DeterminentGaussian()
+		/// <summary>Computes the determinant of a square matrix via Gaussian elimination.</summary>
+		/// <returns>The computed determinant.</returns>
+		public T DeterminantGaussian()
 		{
-			return DeterminentGaussian(this);
+			return DeterminantGaussian(this);
 		}
 
 		#endregion
@@ -1810,8 +1808,8 @@ namespace Towel.Mathematics
 			{
 				throw new MathematicsException("Argument invalid !(" + nameof(a) + "." + nameof(a.IsSquare) + ")");
 			}
-			T determinent = Determinent(a);
-			if (EqualTo(determinent, Constant<T>.Zero))
+			T determinant = Determinant(a);
+			if (EqualTo(determinant, Constant<T>.Zero))
 			{
 				throw new MathematicsException("Singular matrix encountered during inverse caluculation (cannot be inversed).");
 			}
@@ -1835,7 +1833,7 @@ namespace Towel.Mathematics
 			{
 				for (int j = 0; j < dimension; j++)
 				{
-					b.Set(i, j, Division(adjoint.Get(i, j), determinent));
+					b.Set(i, j, Division(adjoint.Get(i, j), determinant));
 				}
 			}
 
@@ -1847,7 +1845,7 @@ namespace Towel.Mathematics
 			//{
 			//    throw new ArgumentNullException(nameof(a));
 			//}
-			//if (Compute.Equal(Determinent(a), Constant<T>.Zero))
+			//if (Compute.Equal(Determinant(a), Constant<T>.Zero))
 			//{
 			//    throw new MathematicsException("inverse calculation failed.");
 			//}
@@ -2009,11 +2007,11 @@ namespace Towel.Mathematics
 			//    {
 			//        if (Compute.IsEven(a.Get(i, j)))
 			//        {
-			//            b[i, j] = Determinent(Minor(a, i, j));
+			//            b[i, j] = Determinant(Minor(a, i, j));
 			//        }
 			//        else
 			//        {
-			//            b[i, j] = Compute.Negate(Determinent(Minor(a, i, j)));
+			//            b[i, j] = Compute.Negate(Determinant(Minor(a, i, j)));
 			//        }
 			//    }
 			//}

--- a/Sources/Towel/Mathematics/Matrix.cs
+++ b/Sources/Towel/Mathematics/Matrix.cs
@@ -1286,6 +1286,7 @@ namespace Towel.Mathematics
 		/// <summary>Computes the determinant of a square matrix via Gaussian elimination.</summary>
 		/// <param name="a">The matrix to compute the determinant of.</param>
 		/// <returns>The computed determinant.</returns>
+		/// <runtime>O((n^3 + 2n^−3) / 3)</runtime>
 		public static T DeterminantGaussian(Matrix<T> a)
 		{
 			_ = a ?? throw new ArgumentNullException(nameof(a));
@@ -1299,6 +1300,7 @@ namespace Towel.Mathematics
 		/// <summary>Computes the determinant of a square matrix via Laplace's method.</summary>
 		/// <param name="a">The matrix to compute the determinant of.</param>
 		/// <returns>The computed determinant.</returns>
+		/// <runtime>O(n(2^(n − 1) − 1))</runtime>
 		public static T DeterminantLaplace(Matrix<T> a)
 		{
 			_ = a ?? throw new ArgumentNullException(nameof(a));

--- a/Sources/Towel/Mathematics/Matrix.cs
+++ b/Sources/Towel/Mathematics/Matrix.cs
@@ -457,6 +457,8 @@ namespace Towel.Mathematics
 
             public MatrixElementFraction<T> Abs()
                 => new MatrixElementFraction<T>(AbsoluteValue(Numerator), AbsoluteValue(Denominator));
+
+            public bool IsDividedByZero => Compare.Default(Denominator, Constant<T>.Zero) == CompareResult.Equal;
         }
 
 		/// <summary>
@@ -517,7 +519,8 @@ namespace Towel.Mathematics
                 }
 			}
 
-            return determinent.Value;
+			// TODO: should we return zero if determinent's denominator is zero?
+            return determinent.IsDividedByZero ? Constant<T>.Zero : determinent.Value;
         }
 
 

--- a/Sources/Towel/Mathematics/Matrix.cs
+++ b/Sources/Towel/Mathematics/Matrix.cs
@@ -545,7 +545,7 @@ namespace Towel.Mathematics
 					Addition(determinent,
 						Multiplication(sign,
 							Multiplication(a.Get(0, f),
-								GetDeterminantGaussian(temp, n - 1))));
+								GetDeterminantLaplace(temp, n - 1))));
 				sign = Negation(sign);
 			}
 			return determinent;

--- a/Sources/Towel/Mathematics/Matrix.cs
+++ b/Sources/Towel/Mathematics/Matrix.cs
@@ -468,19 +468,17 @@ namespace Towel.Mathematics
 		/// <summary>
 		/// Reference: https://codereview.stackexchange.com/questions/204135/determinant-using-gauss-elimination
 		/// </summary>
-		internal static T GetDeterminantGaussian(Matrix<T> src, int n)
+		internal static T GetDeterminantGaussian(Matrix<T> matrix, int n)
 		{
 			// Note: the reasoning behind using MatrixElementFraction is to account for
 			// rounding errors such as 2.00...01 instead of 2
 
 			if (n == 1)
 			{
-				return src.Get(0, 0);
+				return matrix.Get(0, 0);
 			}
-			var determinant = new MatrixElementFraction<T>(Constant<T>.One);
-
-			var fractioned = new Matrix<MatrixElementFraction<T>>(src.Rows, src.Columns, (r, c) => new MatrixElementFraction<T>(src.Get(r, c)));
-			
+			MatrixElementFraction<T> determinant = new MatrixElementFraction<T>(Constant<T>.One);
+			Matrix<MatrixElementFraction<T>> fractioned = new Matrix<MatrixElementFraction<T>>(matrix.Rows, matrix.Columns, (r, c) => new MatrixElementFraction<T>(matrix.Get(r, c)));
 			for (int i = 0; i < n; i++)
 			{
 				var pivotElement = fractioned.Get(i, i);
@@ -502,25 +500,22 @@ namespace Towel.Mathematics
 					Matrix<MatrixElementFraction<T>>.SwapRows(fractioned, i, pivotRow, 0, n - 1);
 					determinant = Negation(determinant);
 				}
-
 				determinant *= pivotElement;
-
-				for (int row = i + 1; row < n; ++row)
+				for (int row = i + 1; row < n; row++)
 				{
-					for (int col = i + 1; col < n; ++col)
+					for (int column = i + 1; column < n; column++)
 					{
-						// from reference: matrix[row][col] -= matrix[row][i] * matrix[i][col] / pivotElement;
-						fractioned.Set(row, col,
+						// reference: matrix[row][column] -= matrix[row][i] * matrix[i][column] / pivotElement;
+						fractioned.Set(row, column,
 							// D - A * B / C
 							D_subtract_A_multiply_B_divide_C<MatrixElementFraction<T>>.Function(
 								fractioned.Get(row, i), /*     A */
-								fractioned.Get(i, col), /*     B */
+								fractioned.Get(i, column), /*     B */
 								pivotElement, /*               C */
-								fractioned.Get(row, col))); /* D */
+								fractioned.Get(row, column))); /* D */
 					}
 				}
 			}
-
 			// TODO: should we return zero if determinant's denominator is zero?
 			return determinant.IsDividedByZero ? Constant<T>.Zero : determinant.Value;
 		}
@@ -529,6 +524,7 @@ namespace Towel.Mathematics
 		#endregion
 
 		#region GetDeterminant Laplace method
+
 		internal static T GetDeterminantLaplace(Matrix<T> a, int n)
 		{
 			T determinant = Constant<T>.Zero;
@@ -550,6 +546,7 @@ namespace Towel.Mathematics
 			}
 			return determinant;
 		}
+
 		#endregion
 
 		#region IsSymetric

--- a/Sources/Towel/Syntax.cs
+++ b/Sources/Towel/Syntax.cs
@@ -30,6 +30,21 @@ namespace Towel
 			};
 		}
 
+		/// <summary>d - a * b / c</summary>
+		internal static class D_subtract_A_multiply_B_divide_C<T>
+		{
+			internal static Func<T, T, T, T, T> Function = (a, b, c, d) =>
+			{
+				ParameterExpression A = Expression.Parameter(typeof(T));
+				ParameterExpression B = Expression.Parameter(typeof(T));
+				ParameterExpression C = Expression.Parameter(typeof(T));
+				ParameterExpression D = Expression.Parameter(typeof(T));
+				Expression BODY = Expression.Subtract(D, Expression.Divide(Expression.Multiply(A, B), C));
+				Function = Expression.Lambda<Func<T, T, T, T, T>>(BODY, A, B, C, D).Compile();
+				return Function(a, b, c, d);
+			};
+		}
+
 		internal static T OperationOnStepper<T>(Stepper<T> stepper, Func<T, T, T> operation)
 		{
 			_ = stepper ?? throw new ArgumentNullException(nameof(stepper));

--- a/Sources/Towel/Syntax.cs
+++ b/Sources/Towel/Syntax.cs
@@ -1414,7 +1414,7 @@ namespace Towel
 						Expression.LessThan(A, Expression.Constant(Constant<T>.Zero)),
 						Expression.Return(RETURN, Expression.Negate(A)),
 						Expression.Return(RETURN, A)),
-					Expression.Label(RETURN, Expression.Constant(default(T))));
+					Expression.Label(RETURN, Expression.Constant(default(T), typeof(T))));
 				Function = Expression.Lambda<Func<T, T>>(BODY, A).Compile();
 				return Function(a);
 			};

--- a/Sources/Towel/Towel.xml
+++ b/Sources/Towel/Towel.xml
@@ -16629,7 +16629,7 @@
             </summary>
             <typeparam name="T"></typeparam>
         </member>
-        <member name="M:Towel.Mathematics.Matrix`1.GetDeterminant(Towel.Mathematics.Matrix{`0},System.Int32)">
+        <member name="M:Towel.Mathematics.Matrix`1.GetDeterminantGaussian(Towel.Mathematics.Matrix{`0},System.Int32)">
             <summary>
             Reference: https://codereview.stackexchange.com/questions/204135/determinant-using-gauss-elimination
             </summary>
@@ -16875,12 +16875,30 @@
             <returns>The resulting matrix of the power operation.</returns>
         </member>
         <member name="M:Towel.Mathematics.Matrix`1.Determinent(Towel.Mathematics.Matrix{`0})">
-            <summary>Computes the determinent of a square matrix.</summary>
+            <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
+            <param name="a">The matrix to compute the determinent of.</param>
+            <returns>The computed determinent.</returns>
+        </member>
+        <member name="M:Towel.Mathematics.Matrix`1.DeterminentGaussian(Towel.Mathematics.Matrix{`0})">
+            <summary>Computes the determinent of a square matrix via Gaussian elimination.</summary>
+            <param name="a">The matrix to compute the determinent of.</param>
+            <returns>The computed determinent.</returns>
+        </member>
+        <member name="M:Towel.Mathematics.Matrix`1.DeterminentLaplace(Towel.Mathematics.Matrix{`0})">
+            <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
             <param name="a">The matrix to compute the determinent of.</param>
             <returns>The computed determinent.</returns>
         </member>
         <member name="M:Towel.Mathematics.Matrix`1.Determinent">
-            <summary>Computes the determinent of a square matrix.</summary>
+            <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
+            <returns>The computed determinent.</returns>
+        </member>
+        <member name="M:Towel.Mathematics.Matrix`1.DeterminentLaplace">
+            <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
+            <returns>The computed determinent.</returns>
+        </member>
+        <member name="M:Towel.Mathematics.Matrix`1.DeterminentGaussian">
+            <summary>Computes the determinent of a square matrix via Gaussian elimination.</summary>
             <returns>The computed determinent.</returns>
         </member>
         <member name="M:Towel.Mathematics.Matrix`1.Trace(Towel.Mathematics.Matrix{`0})">

--- a/Sources/Towel/Towel.xml
+++ b/Sources/Towel/Towel.xml
@@ -16883,11 +16883,13 @@
             <summary>Computes the determinant of a square matrix via Gaussian elimination.</summary>
             <param name="a">The matrix to compute the determinant of.</param>
             <returns>The computed determinant.</returns>
+            <runtime>O((n^3 + 2n^−3) / 3)</runtime>
         </member>
         <member name="M:Towel.Mathematics.Matrix`1.DeterminantLaplace(Towel.Mathematics.Matrix{`0})">
             <summary>Computes the determinant of a square matrix via Laplace's method.</summary>
             <param name="a">The matrix to compute the determinant of.</param>
             <returns>The computed determinant.</returns>
+            <runtime>O(n(2^(n − 1) − 1))</runtime>
         </member>
         <member name="M:Towel.Mathematics.Matrix`1.Determinant">
             <summary>Computes the determinant of a square matrix.</summary>

--- a/Sources/Towel/Towel.xml
+++ b/Sources/Towel/Towel.xml
@@ -16623,6 +16623,17 @@
             <param name="value">The value to assign every spot in the matrix.</param>
             <returns>The newly constructed matrix filled with the uniform value.</returns>
         </member>
+        <member name="T:Towel.Mathematics.Matrix`1.MatrixElementFraction`1">
+            <summary>
+            Used to avoid issues when 1/2 + 1/2 = 0 + 0 = 0 instead of 1 for types, where division results in precision loss
+            </summary>
+            <typeparam name="T"></typeparam>
+        </member>
+        <member name="M:Towel.Mathematics.Matrix`1.GetDeterminant(Towel.Mathematics.Matrix{`0},System.Int32)">
+            <summary>
+            Reference: https://codereview.stackexchange.com/questions/204135/determinant-using-gauss-elimination
+            </summary>
+        </member>
         <member name="M:Towel.Mathematics.Matrix`1.GetIsSymetric(Towel.Mathematics.Matrix{`0})">
             <summary>Determines if the matrix is symetric.</summary>
             <param name="a">The matrix to determine if symetric.</param>

--- a/Sources/Towel/Towel.xml
+++ b/Sources/Towel/Towel.xml
@@ -16874,32 +16874,32 @@
             <param name="b">The power to apply to the matrix.</param>
             <returns>The resulting matrix of the power operation.</returns>
         </member>
-        <member name="M:Towel.Mathematics.Matrix`1.Determinent(Towel.Mathematics.Matrix{`0})">
-            <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
-            <param name="a">The matrix to compute the determinent of.</param>
-            <returns>The computed determinent.</returns>
+        <member name="M:Towel.Mathematics.Matrix`1.Determinant(Towel.Mathematics.Matrix{`0})">
+            <summary>Computes the determinant of a square matrix.</summary>
+            <param name="a">The matrix to compute the determinant of.</param>
+            <returns>The computed determinant.</returns>
         </member>
-        <member name="M:Towel.Mathematics.Matrix`1.DeterminentGaussian(Towel.Mathematics.Matrix{`0})">
-            <summary>Computes the determinent of a square matrix via Gaussian elimination.</summary>
-            <param name="a">The matrix to compute the determinent of.</param>
-            <returns>The computed determinent.</returns>
+        <member name="M:Towel.Mathematics.Matrix`1.DeterminantGaussian(Towel.Mathematics.Matrix{`0})">
+            <summary>Computes the determinant of a square matrix via Gaussian elimination.</summary>
+            <param name="a">The matrix to compute the determinant of.</param>
+            <returns>The computed determinant.</returns>
         </member>
-        <member name="M:Towel.Mathematics.Matrix`1.DeterminentLaplace(Towel.Mathematics.Matrix{`0})">
-            <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
-            <param name="a">The matrix to compute the determinent of.</param>
-            <returns>The computed determinent.</returns>
+        <member name="M:Towel.Mathematics.Matrix`1.DeterminantLaplace(Towel.Mathematics.Matrix{`0})">
+            <summary>Computes the determinant of a square matrix via Laplace's method.</summary>
+            <param name="a">The matrix to compute the determinant of.</param>
+            <returns>The computed determinant.</returns>
         </member>
-        <member name="M:Towel.Mathematics.Matrix`1.Determinent">
-            <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
-            <returns>The computed determinent.</returns>
+        <member name="M:Towel.Mathematics.Matrix`1.Determinant">
+            <summary>Computes the determinant of a square matrix.</summary>
+            <returns>The computed determinant.</returns>
         </member>
-        <member name="M:Towel.Mathematics.Matrix`1.DeterminentLaplace">
-            <summary>Computes the determinent of a square matrix via Laplace's method.</summary>
-            <returns>The computed determinent.</returns>
+        <member name="M:Towel.Mathematics.Matrix`1.DeterminantLaplace">
+            <summary>Computes the determinant of a square matrix via Laplace's method.</summary>
+            <returns>The computed determinant.</returns>
         </member>
-        <member name="M:Towel.Mathematics.Matrix`1.DeterminentGaussian">
-            <summary>Computes the determinent of a square matrix via Gaussian elimination.</summary>
-            <returns>The computed determinent.</returns>
+        <member name="M:Towel.Mathematics.Matrix`1.DeterminantGaussian">
+            <summary>Computes the determinant of a square matrix via Gaussian elimination.</summary>
+            <returns>The computed determinant.</returns>
         </member>
         <member name="M:Towel.Mathematics.Matrix`1.Trace(Towel.Mathematics.Matrix{`0})">
             <summary>Computes the trace of a square matrix.</summary>

--- a/Sources/Towel/Towel.xml
+++ b/Sources/Towel/Towel.xml
@@ -31271,6 +31271,9 @@
         <member name="T:Towel.Syntax.MultiplyAddImplementation`1">
             <summary>a * b + c</summary>
         </member>
+        <member name="T:Towel.Syntax.D_subtract_A_multiply_B_divide_C`1">
+            <summary>d - a * b / c</summary>
+        </member>
         <member name="M:Towel.Syntax.TryParse``1(System.String,``0)">
             <summary>Assumes a TryParse method exists for a generic type and calls it [<see cref="T:System.Boolean"/> TryParse(<see cref="T:System.String"/>, out <typeparamref name="A"/>)].</summary>
             <typeparam name="A">The generic type to make assumptions about.</typeparam>

--- a/Tools/Towel_Testing/Mathematics/Matrix.cs
+++ b/Tools/Towel_Testing/Mathematics/Matrix.cs
@@ -5,8 +5,7 @@ using Towel.Mathematics;
 
 namespace Towel_Testing.Mathematics
 {
-	[TestClass]
-	public class Matrix_Testing
+	[TestClass] public class Matrix_Testing
 	{
 		#region FactoryIdentity
 
@@ -486,15 +485,9 @@ namespace Towel_Testing.Mathematics
 			{
 				Matrix<int> A = new Matrix<int>(3, 3)
 				{
-					[0] = 2,
-					[1] = 3,
-					[2] = -4,
-					[3] = 11,
-					[4] = 8,
-					[5] = 7,
-					[6] = 2,
-					[7] = 5,
-					[8] = 3,
+					[0] =  2, [1] = 3, [2] = -4,
+					[3] = 11, [4] = 8, [5] =  7,
+					[6] =  2, [7] = 5, [8] =  3,
 				};
 				Vector<int> B = new Vector<int>(3, 7, 5);
 				Vector<int> C = new Vector<int>(7, 124, 56);

--- a/Tools/Towel_Testing/Mathematics/Matrix.cs
+++ b/Tools/Towel_Testing/Mathematics/Matrix.cs
@@ -785,7 +785,7 @@ namespace Towel_Testing.Mathematics
 					{ 3, 4, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == -2);
-                Assert.IsTrue(a.DeterminentGaussian() == -2);
+				Assert.IsTrue(a.DeterminentGaussian() == -2);
 			}
 			{
 				Matrix<int> a = new int[,]
@@ -795,7 +795,7 @@ namespace Towel_Testing.Mathematics
 					{ 7, 8, 9, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == 0);
-                Assert.IsTrue(a.DeterminentGaussian() == 0);
+				Assert.IsTrue(a.DeterminentGaussian() == 0);
 			}
 
 			// float
@@ -806,7 +806,7 @@ namespace Towel_Testing.Mathematics
 					{ 3f, 4f, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == -2);
-                Assert.IsTrue(a.DeterminentGaussian() == -2);
+				Assert.IsTrue(a.DeterminentGaussian() == -2);
 			}
 			{
 				Matrix<float> a = new float[,]
@@ -816,7 +816,7 @@ namespace Towel_Testing.Mathematics
 					{ 7f, 8f, 9f, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == 0);
-                Assert.IsTrue(a.DeterminentGaussian() == 0);
+				Assert.IsTrue(a.DeterminentGaussian() == 0);
 			}
 
 			// double
@@ -827,7 +827,7 @@ namespace Towel_Testing.Mathematics
 					{ 3d, 4d, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == -2);
-                Assert.IsTrue(a.DeterminentGaussian() == -2);
+				Assert.IsTrue(a.DeterminentGaussian() == -2);
 			}
 			{
 				Matrix<double> a = new double[,]
@@ -837,7 +837,7 @@ namespace Towel_Testing.Mathematics
 					{ 7d, 8d, 9d, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == 0);
-                Assert.IsTrue(a.DeterminentGaussian() == 0);
+				Assert.IsTrue(a.DeterminentGaussian() == 0);
 			}
 
 			// decimal
@@ -848,7 +848,7 @@ namespace Towel_Testing.Mathematics
 					{ 3m, 4m, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == -2);
-                Assert.IsTrue(a.DeterminentGaussian() == -2);
+				Assert.IsTrue(a.DeterminentGaussian() == -2);
 			}
 			{
 				Matrix<decimal> a = new decimal[,]
@@ -858,7 +858,7 @@ namespace Towel_Testing.Mathematics
 					{ 7m, 8m, 9m, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == 0);
-                Assert.IsTrue(a.DeterminentGaussian() == 0);
+				Assert.IsTrue(a.DeterminentGaussian() == 0);
 			}
 
 			// Exceptions

--- a/Tools/Towel_Testing/Mathematics/Matrix.cs
+++ b/Tools/Towel_Testing/Mathematics/Matrix.cs
@@ -5,879 +5,878 @@ using Towel.Mathematics;
 
 namespace Towel_Testing.Mathematics
 {
-    [TestClass]
-    public class Matrix_Testing
-    {
-
-        #region FactoryIdentity
-
-        [TestMethod]
-        public void FactoryIdentity()
-        {
-            {
-                // 1 x 1
-                Matrix<int> a = Matrix<int>.FactoryIdentity(1, 1);
-                Matrix<int> b = new int[,]
-                {
-                    {1},
-                };
-                Assert.IsTrue(a == b);
-            }
-
-            {
-                // 2 x 2
-                Matrix<int> a = Matrix<int>.FactoryIdentity(2, 2);
-                Matrix<int> b = new int[,]
-                {
-                    {1, 0,},
-                    {0, 1,},
-                };
-                Assert.IsTrue(a == b);
-            }
-
-            {
-                // 3 x 3
-                Matrix<int> a = Matrix<int>.FactoryIdentity(3, 3);
-                Matrix<int> b = new int[,]
-                {
-                    {1, 0, 0,},
-                    {0, 1, 0,},
-                    {0, 0, 1,},
-                };
-                Assert.IsTrue(a == b);
-            }
-
-            {
-                // 4 x 4
-                Matrix<int> a = Matrix<int>.FactoryIdentity(4, 4);
-                Matrix<int> b = new int[,]
-                {
-                    {1, 0, 0, 0,},
-                    {0, 1, 0, 0,},
-                    {0, 0, 1, 0,},
-                    {0, 0, 0, 1,},
-                };
-            }
-
-            // Exceptions
-            {
-                Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryIdentity(0, 1));
-                Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryIdentity(1, 0));
-            }
-        }
-
-        #endregion
-
-        #region FactoryZero
-
-        [TestMethod]
-        public void FactoryZero()
-        {
-            {
-                // 1 x 1
-                Matrix<int> a = Matrix<int>.FactoryZero(1, 1);
-                Matrix<int> b = new int[,]
-                {
-                    {0,},
-                };
-                Assert.IsTrue(a == b);
-            }
-
-            {
-                // 2 x 2
-                Matrix<int> a = Matrix<int>.FactoryZero(2, 2);
-                Matrix<int> b = new int[,]
-                {
-                    {0, 0},
-                    {0, 0},
-                };
-                Assert.IsTrue(a == b);
-            }
-
-            {
-                // 3 x 3
-                Matrix<int> a = Matrix<int>.FactoryZero(3, 3);
-                Matrix<int> b = new int[,]
-                {
-                    {0, 0, 0},
-                    {0, 0, 0},
-                    {0, 0, 0},
-                };
-                Assert.IsTrue(a == b);
-            }
-
-            {
-                // 4 x 4
-                Matrix<int> a = Matrix<int>.FactoryZero(4, 4);
-                Matrix<int> b = new int[,]
-                {
-                    {0, 0, 0, 0},
-                    {0, 0, 0, 0},
-                    {0, 0, 0, 0},
-                    {0, 0, 0, 0},
-                };
-                Assert.IsTrue(a == b);
-            }
-
-            // Exceptions
-            {
-                Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryZero(0, 1));
-                Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryZero(1, 0));
-            }
-        }
-
-        #endregion
-
-        #region Negate
-
-        [TestMethod]
-        public void Negate()
-        {
-            // int
-            {
-                Matrix<int> A = new int[,]
-                {
-                    {1, 2, 3,},
-                    {4, 5, 6,},
-                    {7, 8, 9,},
-                };
-                Matrix<int> B = new int[,]
-                {
-                    {-1, -2, -3,},
-                    {-4, -5, -6,},
-                    {-7, -8, -9,},
-                };
-                Assert.IsTrue(-A == B);
-            }
-
-            // float
-            {
-                Matrix<float> A = new float[,]
-                {
-                    {1f, 2f, 3f,},
-                    {4f, 5f, 6f,},
-                    {7f, 8f, 9f,},
-                };
-                Matrix<float> B = new float[,]
-                {
-                    {-1f, -2f, -3f,},
-                    {-4f, -5f, -6f,},
-                    {-7f, -8f, -9f,},
-                };
-                Assert.IsTrue(-A == B);
-            }
-
-            // double
-            {
-                Matrix<double> A = new double[,]
-                {
-                    {1d, 2d, 3d,},
-                    {4d, 5d, 6d,},
-                    {7d, 8d, 9d,},
-                };
-                Matrix<double> B = new double[,]
-                {
-                    {-1d, -2d, -3d,},
-                    {-4d, -5d, -6d,},
-                    {-7d, -8d, -9d,},
-                };
-                Assert.IsTrue(-A == B);
-            }
-
-            // decimal
-            {
-                Matrix<decimal> A = new decimal[,]
-                {
-                    {1m, 2m, 3m,},
-                    {4m, 5m, 6m,},
-                    {7m, 8m, 9m,},
-                };
-                Matrix<decimal> B = new decimal[,]
-                {
-                    {-1m, -2m, -3m,},
-                    {-4m, -5m, -6m,},
-                    {-7m, -8m, -9m,},
-                };
-                Assert.IsTrue(-A == B);
-            }
-        }
-
-        #endregion
-
-        #region Add
-
-        [TestMethod]
-        public void Add()
-        {
-            // int
-            {
-                Matrix<int> A = new int[,]
-                {
-                    {1, 2, 3,},
-                    {4, 5, 6,},
-                    {7, 8, 9,},
-                };
-                Matrix<int> B = new int[,]
-                {
-                    {2, 4, 6,},
-                    {8, 10, 12,},
-                    {14, 16, 18,},
-                };
-                Assert.IsTrue(A + A == B);
-            }
-
-            // float
-            {
-                Matrix<float> A = new float[,]
-                {
-                    {1f, 2f, 3f,},
-                    {4f, 5f, 6f,},
-                    {7f, 8f, 9f,},
-                };
-                Matrix<float> B = new float[,]
-                {
-                    {2f, 4f, 6f,},
-                    {8f, 10f, 12f,},
-                    {14f, 16f, 18f,},
-                };
-                Assert.IsTrue(A + A == B);
-            }
-
-            // double
-            {
-                Matrix<double> A = new double[,]
-                {
-                    {1d, 2d, 3d,},
-                    {4d, 5d, 6d,},
-                    {7d, 8d, 9d,},
-                };
-                Matrix<double> B = new double[,]
-                {
-                    {2d, 4d, 6d,},
-                    {8d, 10d, 12d,},
-                    {14d, 16d, 18d,},
-                };
-                Assert.IsTrue(A + A == B);
-            }
-
-            // decimal
-            {
-                Matrix<decimal> A = new decimal[,]
-                {
-                    {1m, 2m, 3m,},
-                    {4m, 5m, 6m,},
-                    {7m, 8m, 9m,},
-                };
-                Matrix<decimal> B = new decimal[,]
-                {
-                    {2m, 4m, 6m,},
-                    {8m, 10m, 12m,},
-                    {14m, 16m, 18m,},
-                };
-                Assert.IsTrue(A + A == B);
-            }
-
-            // Exceptions
-            {
-                Matrix<decimal> A = new Matrix<decimal>(2, 2);
-                Matrix<decimal> B = new Matrix<decimal>(3, 3);
-                Assert.ThrowsException<MathematicsException>(() => A + B);
-            }
-        }
-
-        #endregion
-
-        #region Subtract
-
-        [TestMethod]
-        public void Subtract()
-        {
-            // int
-            {
-                Matrix<int> A = new int[,]
-                {
-                    {3, 5, 7,},
-                    {9, 11, 13,},
-                    {15, 17, 19,},
-                };
-                Matrix<int> B = new int[,]
-                {
-                    {2, 3, 4,},
-                    {5, 6, 7,},
-                    {8, 9, 10,},
-                };
-                Matrix<int> C = new int[,]
-                {
-                    {1, 2, 3,},
-                    {4, 5, 6,},
-                    {7, 8, 9,},
-                };
-                Assert.IsTrue(A - B == C);
-            }
-
-            // float
-            {
-                Matrix<float> A = new float[,]
-                {
-                    {3f, 5f, 7f,},
-                    {9f, 11f, 13f,},
-                    {15f, 17f, 19f,},
-                };
-                Matrix<float> B = new float[,]
-                {
-                    {2f, 3f, 4f,},
-                    {5f, 6f, 7f,},
-                    {8f, 9f, 10f,},
-                };
-                Matrix<float> C = new float[,]
-                {
-                    {1f, 2f, 3f,},
-                    {4f, 5f, 6f,},
-                    {7f, 8f, 9f,},
-                };
-                Assert.IsTrue(A - B == C);
-            }
-
-            // double
-            {
-                Matrix<double> A = new double[,]
-                {
-                    {3d, 5d, 7d,},
-                    {9d, 11d, 13d,},
-                    {15d, 17d, 19d,},
-                };
-                Matrix<double> B = new double[,]
-                {
-                    {2d, 3d, 4d,},
-                    {5d, 6d, 7d,},
-                    {8d, 9d, 10d,},
-                };
-                Matrix<double> C = new double[,]
-                {
-                    {1d, 2d, 3d,},
-                    {4d, 5d, 6d,},
-                    {7d, 8d, 9d,},
-                };
-                Assert.IsTrue(A - B == C);
-            }
-
-            // decimal
-            {
-                Matrix<decimal> A = new decimal[,]
-                {
-                    {3m, 5m, 7m,},
-                    {9m, 11m, 13m,},
-                    {15m, 17m, 19m,},
-                };
-                Matrix<decimal> B = new decimal[,]
-                {
-                    {2m, 3m, 4m,},
-                    {5m, 6m, 7m,},
-                    {8m, 9m, 10m,},
-                };
-                Matrix<decimal> C = new decimal[,]
-                {
-                    {1m, 2m, 3m,},
-                    {4m, 5m, 6m,},
-                    {7m, 8m, 9m,},
-                };
-                Assert.IsTrue(A - B == C);
-            }
-
-            // Exceptions
-            {
-                Matrix<decimal> A = new Matrix<decimal>(2, 2);
-                Matrix<decimal> B = new Matrix<decimal>(3, 3);
-                Assert.ThrowsException<MathematicsException>(() => A - B);
-            }
-        }
-
-        #endregion
-
-        #region Multiply_Matrix
-
-        [TestMethod]
-        public void Multiply_Matrix()
-        {
-            // int
-            {
-                Matrix<int> A = new int[,]
-                {
-                    {1, 2, 3,},
-                    {4, 5, 6,},
-                };
-                Matrix<int> B = new int[,]
-                {
-                    {7, 8,},
-                    {9, 10,},
-                    {11, 12,},
-                };
-                Matrix<int> C = new int[,]
-                {
-                    {58, 64,},
-                    {139, 154,},
-                };
-                Assert.IsTrue(A * B == C);
-            }
-
-            // float
-            {
-                Matrix<float> A = new float[,]
-                {
-                    {1f, 2f, 3f,},
-                    {4f, 5f, 6f,},
-                };
-                Matrix<float> B = new float[,]
-                {
-                    {7f, 8f,},
-                    {9f, 10f,},
-                    {11f, 12f,},
-                };
-                Matrix<float> C = new float[,]
-                {
-                    {58f, 64f,},
-                    {139f, 154f,},
-                };
-                Assert.IsTrue(A * B == C);
-            }
-
-            // double
-            {
-                Matrix<double> A = new double[,]
-                {
-                    {1d, 2d, 3d,},
-                    {4d, 5d, 6d,},
-                };
-                Matrix<double> B = new double[,]
-                {
-                    {7d, 8d,},
-                    {9d, 10d,},
-                    {11d, 12d,},
-                };
-                Matrix<double> C = new double[,]
-                {
-                    {58d, 64d,},
-                    {139d, 154d,},
-                };
-                Assert.IsTrue(A * B == C);
-            }
-
-            // decimal
-            {
-                Matrix<decimal> A = new decimal[,]
-                {
-                    {1m, 2m, 3m,},
-                    {4m, 5m, 6m,},
-                };
-                Matrix<decimal> B = new decimal[,]
-                {
-                    {7m, 8m,},
-                    {9m, 10m,},
-                    {11m, 12m,},
-                };
-                Matrix<decimal> C = new decimal[,]
-                {
-                    {58m, 64m,},
-                    {139m, 154m,},
-                };
-                Assert.IsTrue(A * B == C);
-            }
-
-            // Exceptions
-            {
-                Matrix<decimal> A = new Matrix<decimal>(2, 2);
-                Matrix<decimal> B = new Matrix<decimal>(3, 3);
-                Assert.ThrowsException<MathematicsException>(() => A * B);
-            }
-        }
-
-        #endregion
-
-        #region Multiply_Vector
-
-        [TestMethod]
-        public void Multiply_Vector()
-        {
-            // int
-            {
-                Matrix<int> A = new Matrix<int>(3, 3)
-                {
-                    [0] = 2, [1] = 3, [2] = -4,
-                    [3] = 11, [4] = 8, [5] = 7,
-                    [6] = 2, [7] = 5, [8] = 3,
-                };
-                Vector<int> B = new Vector<int>(3, 7, 5);
-                Vector<int> C = new Vector<int>(7, 124, 56);
-                Assert.IsTrue(A * B == C);
-            }
-
-            // float
-            {
-                Matrix<float> A = new float[,]
-                {
-                    {2f, 3f, -4f,},
-                    {11f, 8f, 7f,},
-                    {2f, 5f, 3f,},
-                };
-                Vector<float> B = new Vector<float>(3, 7, 5);
-                Vector<float> C = new Vector<float>(7, 124, 56);
-                Assert.IsTrue(A * B == C);
-            }
-
-            // double
-            {
-                Matrix<double> A = new double[,]
-                {
-                    {2d, 3d, -4d,},
-                    {11d, 8d, 7d,},
-                    {2d, 5d, 3d,},
-                };
-                Vector<double> B = new Vector<double>(3d, 7d, 5d);
-                Vector<double> C = new Vector<double>(7d, 124d, 56d);
-                Assert.IsTrue(A * B == C);
-            }
-
-            // decimal
-            {
-                Matrix<decimal> A = new decimal[,]
-                {
-                    {2m, 3m, -4m,},
-                    {11m, 8m, 7m,},
-                    {2m, 5m, 3m,},
-                };
-                Vector<decimal> B = new Vector<decimal>(3m, 7m, 5m);
-                Vector<decimal> C = new Vector<decimal>(7m, 124m, 56m);
-                Assert.IsTrue(A * B == C);
-            }
-
-            // Exceptions
-            {
-                Vector<int> V = new Vector<int>(1);
-                Matrix<int> M = new Matrix<int>(2, 2);
-                Assert.ThrowsException<MathematicsException>(() => M * V);
-            }
-        }
-
-        #endregion
-
-        #region Multiply_Scalar
-
-        [TestMethod]
-        public void Multiply_Scalar()
-        {
-            // int
-            {
-                Matrix<int> A = new int[,]
-                {
-                    {1, 2, 3,},
-                    {4, 5, 6,},
-                    {7, 8, 9,},
-                };
-                Matrix<int> B = new int[,]
-                {
-                    {2, 4, 6,},
-                    {8, 10, 12,},
-                    {14, 16, 18,},
-                };
-                Assert.IsTrue(A * 2 == B);
-            }
-
-            // float
-            {
-                Matrix<float> A = new float[,]
-                {
-                    {1f, 2f, 3f,},
-                    {4f, 5f, 6f,},
-                    {7f, 8f, 9f,},
-                };
-                Matrix<float> B = new float[,]
-                {
-                    {2f, 4f, 6f,},
-                    {8f, 10f, 12f,},
-                    {14f, 16f, 18f,},
-                };
-                Assert.IsTrue(A * 2f == B);
-            }
-
-            // double
-            {
-                Matrix<double> A = new double[,]
-                {
-                    {1d, 2d, 3d,},
-                    {4d, 5d, 6d,},
-                    {7d, 8d, 9d,},
-                };
-                Matrix<double> B = new double[,]
-                {
-                    {2d, 4d, 6d,},
-                    {8d, 10d, 12d,},
-                    {14d, 16d, 18d,},
-                };
-                Assert.IsTrue(A * 2d == B);
-            }
-
-            // decimal
-            {
-                Matrix<decimal> A = new decimal[,]
-                {
-                    {1m, 2m, 3m,},
-                    {4m, 5m, 6m,},
-                    {7m, 8m, 9m,},
-                };
-                Matrix<decimal> B = new decimal[,]
-                {
-                    {2m, 4m, 6m,},
-                    {8m, 10m, 12m,},
-                    {14m, 16m, 18m,},
-                };
-                Assert.IsTrue(A * 2m == B);
-            }
-        }
-
-        #endregion
-
-        #region Divide
-
-        [TestMethod]
-        public void Divide()
-        {
-            // int
-            {
-                Matrix<int> A = new int[,]
-                {
-                    {2, 4, 6,},
-                    {8, 10, 12,},
-                    {14, 16, 18,},
-                };
-                Matrix<int> B = new int[,]
-                {
-                    {1, 2, 3,},
-                    {4, 5, 6,},
-                    {7, 8, 9,},
-                };
-                Assert.IsTrue(A / 2 == B);
-            }
-
-            // float
-            {
-                Matrix<float> A = new float[,]
-                {
-                    {2f, 4f, 6f,},
-                    {8f, 10f, 12f,},
-                    {14f, 16f, 18f,},
-                };
-                Matrix<float> B = new float[,]
-                {
-                    {1f, 2f, 3f,},
-                    {4f, 5f, 6f,},
-                    {7f, 8f, 9f,},
-                };
-                Assert.IsTrue(A / 2f == B);
-            }
-
-            // double
-            {
-                Matrix<double> A = new double[,]
-                {
-                    {2d, 4d, 6d,},
-                    {8d, 10d, 12d,},
-                    {14d, 16d, 18d,},
-                };
-                Matrix<double> B = new double[,]
-                {
-                    {1d, 2d, 3d,},
-                    {4d, 5d, 6d,},
-                    {7d, 8d, 9d,},
-                };
-                Assert.IsTrue(A / 2d == B);
-            }
-
-            // decimal
-            {
-                Matrix<decimal> A = new decimal[,]
-                {
-                    {2m, 4m, 6m,},
-                    {8m, 10m, 12m,},
-                    {14m, 16m, 18m,},
-                };
-                Matrix<decimal> B = new decimal[,]
-                {
-                    {1m, 2m, 3m,},
-                    {4m, 5m, 6m,},
-                    {7m, 8m, 9m,},
-                };
-                Assert.IsTrue(A / 2m == B);
-            }
-        }
-
-        #endregion
-
-        #region Power
-
-        [TestMethod]
-        public void Power()
-        {
-            // int
-            {
-                Matrix<int> A = new int[,]
-                {
-                    {1, 2,},
-                    {3, 4,},
-                };
-                Matrix<int> B = new int[,]
-                {
-                    {37, 54,},
-                    {81, 118,},
-                };
-                Assert.IsTrue((A ^ 3) == B);
-            }
-
-            // float
-            {
-                Matrix<float> A = new float[,]
-                {
-                    {1f, 2f,},
-                    {3f, 4f,},
-                };
-                Matrix<float> B = new float[,]
-                {
-                    {37f, 54f,},
-                    {81f, 118f,},
-                };
-                Assert.IsTrue((A ^ 3) == B);
-            }
-
-            // double
-            {
-                Matrix<double> A = new double[,]
-                {
-                    {1d, 2d,},
-                    {3d, 4d,},
-                };
-                Matrix<double> B = new double[,]
-                {
-                    {37d, 54d,},
-                    {81d, 118d,},
-                };
-                Assert.IsTrue((A ^ 3) == B);
-            }
-
-            // decimal
-            {
-                Matrix<decimal> A = new decimal[,]
-                {
-                    {1m, 2m,},
-                    {3m, 4m,},
-                };
-                Matrix<decimal> B = new decimal[,]
-                {
-                    {37m, 54m,},
-                    {81m, 118m,},
-                };
-                Assert.IsTrue((A ^ 3) == B);
-            }
-
-            // Exceptions
-            {
-                Matrix<decimal> A = new Matrix<decimal>(2, 3);
-                Assert.ThrowsException<MathematicsException>(() => A ^ 3);
-            }
-        }
-
-        #endregion
-
-        #region Determinent
-
-        public void CheckDet<T>(T[,] data, T expected)
-        {
-            Matrix<T> a = data;
-            var actual = a.Determinent();
-            var error = Syntax.AbsoluteValue(Syntax.Subtraction(actual, expected));
-            Assert.IsTrue(Syntax.LessThan(error, Syntax.Convert<float, T>(0.1f)) || Syntax.Comparison(error, Constant<T>.Zero) == CompareResult.Equal,
-				$"actual: {actual}  expected: {expected}  error: {error}");
-        }
-
-        [TestMethod]
-        public void DeterminentInt1()
-        => CheckDet(new int[,]
-            {
-                {1, 2,},
-                {3, 4,},
-            }, -2);
-
-        [TestMethod]
-        public void DeterminentInt2()
-            => CheckDet(new int[,]
-                {
-                    {1, 2, 3,},
-                    {4, 5, 6,},
-                    {7, 8, 9,},
-                }, 0);
-
-        [TestMethod]
-        public void DeterminentFloat1()
-        => CheckDet(new float[,]
-            {
-                {1f, 2f,},
-                {3f, 4f,},
-            }, -2);
-
-        [TestMethod]
-        public void DeterminentFloat2()
-            => CheckDet(new float[,]
-            {
-                {1f, 2f, 3f,},
-                {4f, 5f, 6f,},
-                {7f, 8f, 9f,},
-            }, 0);
-
-
-        [TestMethod]
-        public void DeterminentDouble1()
-        => CheckDet(new double[,]
-            {
-                {1d, 2d,},
-                {3d, 4d,},
-            }, -2);
-
-        [TestMethod]
-        public void DeterminentDouble2()
-            => CheckDet(new double[,]
-            {
-                {1d, 2d, 3d,},
-                {4d, 5d, 6d,},
-                {7d, 8d, 9d,},
-            }, 0);
-
-        [TestMethod]
-        public void DeterminentDecimal1()
-            => CheckDet(new decimal[,]
-            {
-                {1m, 2m,},
-                {3m, 4m,},
-            }, -2);
-
-        [TestMethod]
-        public void DeterminentDecimal2()
-            => CheckDet(new decimal[,]
-                {
-                    {1m, 2m, 3m,},
-                    {4m, 5m, 6m,},
-                    {7m, 8m, 9m,},
-                }, 0);
-
-        [TestMethod]
-        public void DeterminentException()
+	[TestClass]
+	public class Matrix_Testing
+	{
+		#region FactoryIdentity
+
+		[TestMethod]
+		public void FactoryIdentity()
 		{
-			Matrix<decimal> a = new Matrix<decimal>(2, 3);
-			Assert.ThrowsException<MathematicsException>(() => a.Determinent());
+			{ // 1 x 1
+				Matrix<int> a = Matrix<int>.FactoryIdentity(1, 1);
+				Matrix<int> b = new int[,]
+				{
+					{ 1 },
+				};
+				Assert.IsTrue(a == b);
+			}
+
+			{ // 2 x 2
+				Matrix<int> a = Matrix<int>.FactoryIdentity(2, 2);
+				Matrix<int> b = new int[,]
+				{
+					{ 1, 0, },
+					{ 0, 1, },
+				};
+				Assert.IsTrue(a == b);
+			}
+
+			{ // 3 x 3
+				Matrix<int> a = Matrix<int>.FactoryIdentity(3, 3);
+				Matrix<int> b = new int[,]
+				{
+					{ 1, 0, 0, },
+					{ 0, 1, 0, },
+					{ 0, 0, 1, },
+				};
+				Assert.IsTrue(a == b);
+			}
+
+			{ // 4 x 4
+				Matrix<int> a = Matrix<int>.FactoryIdentity(4, 4);
+				Matrix<int> b = new int[,]
+				{
+					{ 1, 0, 0, 0, },
+					{ 0, 1, 0, 0, },
+					{ 0, 0, 1, 0, },
+					{ 0, 0, 0, 1, },
+				};
+			}
+
+			// Exceptions
+			{
+				Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryIdentity(0, 1));
+				Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryIdentity(1, 0));
+			}
 		}
 
-        #endregion
+		#endregion
+
+		#region FactoryZero
+
+		[TestMethod]
+		public void FactoryZero()
+		{
+			{ // 1 x 1
+				Matrix<int> a = Matrix<int>.FactoryZero(1, 1);
+				Matrix<int> b = new int[,]
+				{
+					{ 0, },
+				};
+				Assert.IsTrue(a == b);
+			}
+
+			{ // 2 x 2
+				Matrix<int> a = Matrix<int>.FactoryZero(2, 2);
+				Matrix<int> b = new int[,]
+				{
+					{ 0, 0 },
+					{ 0, 0 },
+				};
+				Assert.IsTrue(a == b);
+			}
+
+			{ // 3 x 3
+				Matrix<int> a = Matrix<int>.FactoryZero(3, 3);
+				Matrix<int> b = new int[,]
+				{
+					{ 0, 0, 0 },
+					{ 0, 0, 0 },
+					{ 0, 0, 0 },
+				};
+				Assert.IsTrue(a == b);
+			}
+
+			{ // 4 x 4
+				Matrix<int> a = Matrix<int>.FactoryZero(4, 4);
+				Matrix<int> b = new int[,]
+				{
+					{ 0, 0, 0, 0 },
+					{ 0, 0, 0, 0 },
+					{ 0, 0, 0, 0 },
+					{ 0, 0, 0, 0 },
+				};
+				Assert.IsTrue(a == b);
+			}
+
+			// Exceptions
+			{
+				Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryZero(0, 1));
+				Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryZero(1, 0));
+			}
+		}
+
+		#endregion
+
+		#region Negate
+
+		[TestMethod]
+		public void Negate()
+		{
+			// int
+			{
+				Matrix<int> A = new int[,]
+				{
+					{ 1, 2, 3, },
+					{ 4, 5, 6, },
+					{ 7, 8, 9, },
+				};
+				Matrix<int> B = new int[,]
+				{
+					{ -1, -2, -3, },
+					{ -4, -5, -6, },
+					{ -7, -8, -9, },
+				};
+				Assert.IsTrue(-A == B);
+			}
+
+			// float
+			{
+				Matrix<float> A = new float[,]
+				{
+					{ 1f, 2f, 3f, },
+					{ 4f, 5f, 6f, },
+					{ 7f, 8f, 9f, },
+				};
+				Matrix<float> B = new float[,]
+				{
+					{ -1f, -2f, -3f, },
+					{ -4f, -5f, -6f, },
+					{ -7f, -8f, -9f, },
+				};
+				Assert.IsTrue(-A == B);
+			}
+
+			// double
+			{
+				Matrix<double> A = new double[,]
+				{
+					{ 1d, 2d, 3d, },
+					{ 4d, 5d, 6d, },
+					{ 7d, 8d, 9d, },
+				};
+				Matrix<double> B = new double[,]
+				{
+					{ -1d, -2d, -3d, },
+					{ -4d, -5d, -6d, },
+					{ -7d, -8d, -9d, },
+				};
+				Assert.IsTrue(-A == B);
+			}
+
+			// decimal
+			{
+				Matrix<decimal> A = new decimal[,]
+				{
+					{ 1m, 2m, 3m, },
+					{ 4m, 5m, 6m, },
+					{ 7m, 8m, 9m, },
+				};
+				Matrix<decimal> B = new decimal[,]
+				{
+					{ -1m, -2m, -3m, },
+					{ -4m, -5m, -6m, },
+					{ -7m, -8m, -9m, },
+				};
+				Assert.IsTrue(-A == B);
+			}
+		}
+
+		#endregion
+
+		#region Add
+
+		[TestMethod]
+		public void Add()
+		{
+			// int
+			{
+				Matrix<int> A = new int[,]
+				{
+					{ 1, 2, 3, },
+					{ 4, 5, 6, },
+					{ 7, 8, 9, },
+				};
+				Matrix<int> B = new int[,]
+				{
+					{  2,  4,  6, },
+					{  8, 10, 12, },
+					{ 14, 16, 18, },
+				};
+				Assert.IsTrue(A + A == B);
+			}
+
+			// float
+			{
+				Matrix<float> A = new float[,]
+				{
+					{ 1f, 2f, 3f, },
+					{ 4f, 5f, 6f, },
+					{ 7f, 8f, 9f, },
+				};
+				Matrix<float> B = new float[,]
+				{
+					{  2f,  4f,  6f, },
+					{  8f, 10f, 12f, },
+					{ 14f, 16f, 18f, },
+				};
+				Assert.IsTrue(A + A == B);
+			}
+
+			// double
+			{
+				Matrix<double> A = new double[,]
+				{
+					{ 1d, 2d, 3d, },
+					{ 4d, 5d, 6d, },
+					{ 7d, 8d, 9d, },
+				};
+				Matrix<double> B = new double[,]
+				{
+					{  2d,  4d,  6d, },
+					{  8d, 10d, 12d, },
+					{ 14d, 16d, 18d, },
+				};
+				Assert.IsTrue(A + A == B);
+			}
+
+			// decimal
+			{
+				Matrix<decimal> A = new decimal[,]
+				{
+					{ 1m, 2m, 3m, },
+					{ 4m, 5m, 6m, },
+					{ 7m, 8m, 9m, },
+				};
+				Matrix<decimal> B = new decimal[,]
+				{
+					{  2m,  4m,  6m, },
+					{  8m, 10m, 12m, },
+					{ 14m, 16m, 18m, },
+				};
+				Assert.IsTrue(A + A == B);
+			}
+
+			// Exceptions
+			{
+				Matrix<decimal> A = new Matrix<decimal>(2, 2);
+				Matrix<decimal> B = new Matrix<decimal>(3, 3);
+				Assert.ThrowsException<MathematicsException>(() => A + B);
+			}
+		}
+
+		#endregion
+
+		#region Subtract
+
+		[TestMethod]
+		public void Subtract()
+		{
+			// int
+			{
+				Matrix<int> A = new int[,]
+				{
+					{  3,  5,  7, },
+					{  9, 11, 13, },
+					{ 15, 17, 19, },
+				};
+				Matrix<int> B = new int[,]
+				{
+					{ 2, 3,  4, },
+					{ 5, 6,  7, },
+					{ 8, 9, 10, },
+				};
+				Matrix<int> C = new int[,]
+				{
+					{ 1, 2, 3, },
+					{ 4, 5, 6, },
+					{ 7, 8, 9, },
+				};
+				Assert.IsTrue(A - B == C);
+			}
+
+			// float
+			{
+				Matrix<float> A = new float[,]
+				{
+					{  3f,  5f,  7f, },
+					{  9f, 11f, 13f, },
+					{ 15f, 17f, 19f, },
+				};
+				Matrix<float> B = new float[,]
+				{
+					{ 2f, 3f,  4f, },
+					{ 5f, 6f,  7f, },
+					{ 8f, 9f, 10f, },
+				};
+				Matrix<float> C = new float[,]
+				{
+					{ 1f, 2f, 3f, },
+					{ 4f, 5f, 6f, },
+					{ 7f, 8f, 9f, },
+				};
+				Assert.IsTrue(A - B == C);
+			}
+
+			// double
+			{
+				Matrix<double> A = new double[,]
+				{
+					{  3d,  5d,  7d, },
+					{  9d, 11d, 13d, },
+					{ 15d, 17d, 19d, },
+				};
+				Matrix<double> B = new double[,]
+				{
+					{ 2d, 3d,  4d, },
+					{ 5d, 6d,  7d, },
+					{ 8d, 9d, 10d, },
+				};
+				Matrix<double> C = new double[,]
+				{
+					{ 1d, 2d, 3d, },
+					{ 4d, 5d, 6d, },
+					{ 7d, 8d, 9d, },
+				};
+				Assert.IsTrue(A - B == C);
+			}
+
+			// decimal
+			{
+				Matrix<decimal> A = new decimal[,]
+				{
+					{  3m,  5m,  7m, },
+					{  9m, 11m, 13m, },
+					{ 15m, 17m, 19m, },
+				};
+				Matrix<decimal> B = new decimal[,]
+				{
+					{ 2m, 3m,  4m, },
+					{ 5m, 6m,  7m, },
+					{ 8m, 9m, 10m, },
+				};
+				Matrix<decimal> C = new decimal[,]
+				{
+					{ 1m, 2m, 3m, },
+					{ 4m, 5m, 6m, },
+					{ 7m, 8m, 9m, },
+				};
+				Assert.IsTrue(A - B == C);
+			}
+
+			// Exceptions
+			{
+				Matrix<decimal> A = new Matrix<decimal>(2, 2);
+				Matrix<decimal> B = new Matrix<decimal>(3, 3);
+				Assert.ThrowsException<MathematicsException>(() => A - B);
+			}
+		}
+
+		#endregion
+
+		#region Multiply_Matrix
+
+		[TestMethod]
+		public void Multiply_Matrix()
+		{
+			// int
+			{
+				Matrix<int> A = new int[,]
+				{
+					{ 1, 2, 3, },
+					{ 4, 5, 6, },
+				};
+				Matrix<int> B = new int[,]
+				{
+					{  7,  8, },
+					{  9, 10, },
+					{ 11, 12, },
+				};
+				Matrix<int> C = new int[,]
+				{
+					{  58,  64, },
+					{ 139, 154, },
+				};
+				Assert.IsTrue(A * B == C);
+			}
+
+			// float
+			{
+				Matrix<float> A = new float[,]
+				{
+					{ 1f, 2f, 3f, },
+					{ 4f, 5f, 6f, },
+				};
+				Matrix<float> B = new float[,]
+				{
+					{  7f,  8f, },
+					{  9f, 10f, },
+					{ 11f, 12f, },
+				};
+				Matrix<float> C = new float[,]
+				{
+					{  58f,  64f, },
+					{ 139f, 154f, },
+				};
+				Assert.IsTrue(A * B == C);
+			}
+
+			// double
+			{
+				Matrix<double> A = new double[,]
+				{
+					{ 1d, 2d, 3d, },
+					{ 4d, 5d, 6d, },
+				};
+				Matrix<double> B = new double[,]
+				{
+					{  7d,  8d, },
+					{  9d, 10d, },
+					{ 11d, 12d, },
+				};
+				Matrix<double> C = new double[,]
+				{
+					{  58d,  64d, },
+					{ 139d, 154d, },
+				};
+				Assert.IsTrue(A * B == C);
+			}
+
+			// decimal
+			{
+				Matrix<decimal> A = new decimal[,]
+				{
+					{ 1m, 2m, 3m, },
+					{ 4m, 5m, 6m, },
+				};
+				Matrix<decimal> B = new decimal[,]
+				{
+					{  7m,  8m, },
+					{  9m, 10m, },
+					{ 11m, 12m, },
+				};
+				Matrix<decimal> C = new decimal[,]
+				{
+					{  58m,  64m, },
+					{ 139m, 154m, },
+				};
+				Assert.IsTrue(A * B == C);
+			}
+
+			// Exceptions
+			{
+				Matrix<decimal> A = new Matrix<decimal>(2, 2);
+				Matrix<decimal> B = new Matrix<decimal>(3, 3);
+				Assert.ThrowsException<MathematicsException>(() => A * B);
+			}
+		}
+
+		#endregion
+
+		#region Multiply_Vector
+
+		[TestMethod]
+		public void Multiply_Vector()
+		{
+			// int
+			{
+				Matrix<int> A = new Matrix<int>(3, 3)
+				{
+					[0] = 2,
+					[1] = 3,
+					[2] = -4,
+					[3] = 11,
+					[4] = 8,
+					[5] = 7,
+					[6] = 2,
+					[7] = 5,
+					[8] = 3,
+				};
+				Vector<int> B = new Vector<int>(3, 7, 5);
+				Vector<int> C = new Vector<int>(7, 124, 56);
+				Assert.IsTrue(A * B == C);
+			}
+
+			// float
+			{
+				Matrix<float> A = new float[,]
+				{
+					{  2f, 3f, -4f, },
+					{ 11f, 8f,  7f, },
+					{  2f, 5f,  3f, },
+				};
+				Vector<float> B = new Vector<float>(3, 7, 5);
+				Vector<float> C = new Vector<float>(7, 124, 56);
+				Assert.IsTrue(A * B == C);
+			}
+
+			// double
+			{
+				Matrix<double> A = new double[,]
+				{
+					{  2d, 3d, -4d, },
+					{ 11d, 8d,  7d, },
+					{  2d, 5d,  3d, },
+				};
+				Vector<double> B = new Vector<double>(3d, 7d, 5d);
+				Vector<double> C = new Vector<double>(7d, 124d, 56d);
+				Assert.IsTrue(A * B == C);
+			}
+
+			// decimal
+			{
+				Matrix<decimal> A = new decimal[,]
+				{
+					{  2m, 3m, -4m, },
+					{ 11m, 8m,  7m, },
+					{  2m, 5m,  3m, },
+				};
+				Vector<decimal> B = new Vector<decimal>(3m, 7m, 5m);
+				Vector<decimal> C = new Vector<decimal>(7m, 124m, 56m);
+				Assert.IsTrue(A * B == C);
+			}
+
+			// Exceptions
+			{
+				Vector<int> V = new Vector<int>(1);
+				Matrix<int> M = new Matrix<int>(2, 2);
+				Assert.ThrowsException<MathematicsException>(() => M * V);
+			}
+		}
+
+		#endregion
+
+		#region Multiply_Scalar
+
+		[TestMethod]
+		public void Multiply_Scalar()
+		{
+			// int
+			{
+				Matrix<int> A = new int[,]
+				{
+					{ 1, 2, 3, },
+					{ 4, 5, 6, },
+					{ 7, 8, 9, },
+				};
+				Matrix<int> B = new int[,]
+				{
+					{  2,  4,  6, },
+					{  8, 10, 12, },
+					{ 14, 16, 18, },
+				};
+				Assert.IsTrue(A * 2 == B);
+			}
+
+			// float
+			{
+				Matrix<float> A = new float[,]
+				{
+					{ 1f, 2f, 3f, },
+					{ 4f, 5f, 6f, },
+					{ 7f, 8f, 9f, },
+				};
+				Matrix<float> B = new float[,]
+				{
+					{  2f,  4f,  6f, },
+					{  8f, 10f, 12f, },
+					{ 14f, 16f, 18f, },
+				};
+				Assert.IsTrue(A * 2f == B);
+			}
+
+			// double
+			{
+				Matrix<double> A = new double[,]
+				{
+					{ 1d, 2d, 3d, },
+					{ 4d, 5d, 6d, },
+					{ 7d, 8d, 9d, },
+				};
+				Matrix<double> B = new double[,]
+				{
+					{  2d,  4d,  6d, },
+					{  8d, 10d, 12d, },
+					{ 14d, 16d, 18d, },
+				};
+				Assert.IsTrue(A * 2d == B);
+			}
+
+			// decimal
+			{
+				Matrix<decimal> A = new decimal[,]
+				{
+					{ 1m, 2m, 3m, },
+					{ 4m, 5m, 6m, },
+					{ 7m, 8m, 9m, },
+				};
+				Matrix<decimal> B = new decimal[,]
+				{
+					{  2m,  4m,  6m, },
+					{  8m, 10m, 12m, },
+					{ 14m, 16m, 18m, },
+				};
+				Assert.IsTrue(A * 2m == B);
+			}
+		}
+
+		#endregion
+
+		#region Divide
+
+		[TestMethod]
+		public void Divide()
+		{
+			// int
+			{
+				Matrix<int> A = new int[,]
+				{
+					{  2,  4,  6, },
+					{  8, 10, 12, },
+					{ 14, 16, 18, },
+				};
+				Matrix<int> B = new int[,]
+				{
+					{ 1, 2, 3, },
+					{ 4, 5, 6, },
+					{ 7, 8, 9, },
+				};
+				Assert.IsTrue(A / 2 == B);
+			}
+
+			// float
+			{
+				Matrix<float> A = new float[,]
+				{
+					{  2f,  4f,  6f, },
+					{  8f, 10f, 12f, },
+					{ 14f, 16f, 18f, },
+				};
+				Matrix<float> B = new float[,]
+				{
+					{ 1f, 2f, 3f, },
+					{ 4f, 5f, 6f, },
+					{ 7f, 8f, 9f, },
+				};
+				Assert.IsTrue(A / 2f == B);
+			}
+
+			// double
+			{
+				Matrix<double> A = new double[,]
+				{
+					{  2d,  4d,  6d, },
+					{  8d, 10d, 12d, },
+					{ 14d, 16d, 18d, },
+				};
+				Matrix<double> B = new double[,]
+				{
+					{ 1d, 2d, 3d, },
+					{ 4d, 5d, 6d, },
+					{ 7d, 8d, 9d, },
+				};
+				Assert.IsTrue(A / 2d == B);
+			}
+
+			// decimal
+			{
+				Matrix<decimal> A = new decimal[,]
+				{
+					{  2m,  4m,  6m, },
+					{  8m, 10m, 12m, },
+					{ 14m, 16m, 18m, },
+				};
+				Matrix<decimal> B = new decimal[,]
+				{
+					{ 1m, 2m, 3m, },
+					{ 4m, 5m, 6m, },
+					{ 7m, 8m, 9m, },
+				};
+				Assert.IsTrue(A / 2m == B);
+			}
+		}
+
+		#endregion
+
+		#region Power
+
+		[TestMethod]
+		public void Power()
+		{
+			// int
+			{
+				Matrix<int> A = new int[,]
+				{
+					{ 1, 2, },
+					{ 3, 4, },
+				};
+				Matrix<int> B = new int[,]
+				{
+					{ 37,  54, },
+					{ 81, 118, },
+				};
+				Assert.IsTrue((A ^ 3) == B);
+			}
+
+			// float
+			{
+				Matrix<float> A = new float[,]
+				{
+					{ 1f, 2f, },
+					{ 3f, 4f, },
+				};
+				Matrix<float> B = new float[,]
+				{
+					{ 37f,  54f, },
+					{ 81f, 118f, },
+				};
+				Assert.IsTrue((A ^ 3) == B);
+			}
+
+			// double
+			{
+				Matrix<double> A = new double[,]
+				{
+					{ 1d, 2d, },
+					{ 3d, 4d, },
+				};
+				Matrix<double> B = new double[,]
+				{
+					{ 37d,  54d, },
+					{ 81d, 118d, },
+				};
+				Assert.IsTrue((A ^ 3) == B);
+			}
+
+			// decimal
+			{
+				Matrix<decimal> A = new decimal[,]
+				{
+					{ 1m, 2m, },
+					{ 3m, 4m, },
+				};
+				Matrix<decimal> B = new decimal[,]
+				{
+					{ 37m,  54m, },
+					{ 81m, 118m, },
+				};
+				Assert.IsTrue((A ^ 3) == B);
+			}
+
+			// Exceptions
+			{
+				Matrix<decimal> A = new Matrix<decimal>(2, 3);
+				Assert.ThrowsException<MathematicsException>(() => A ^ 3);
+			}
+		}
+
+		#endregion
+
+		#region Determinent
+
+		[TestMethod]
+		public void Determinent()
+		{
+			// int 
+			{
+				Matrix<int> a = new int[,]
+				{
+					{ 1, 2, },
+					{ 3, 4, },
+				};
+				Assert.IsTrue(a.Determinent() == -2);
+			}
+			{
+				Matrix<int> a = new int[,]
+				{
+					{ 1, 2, 3, },
+					{ 4, 5, 6, },
+					{ 7, 8, 9, },
+				};
+				Assert.IsTrue(a.Determinent() == 0);
+			}
+
+			// float
+			{
+				Matrix<float> a = new float[,]
+				{
+					{ 1f, 2f, },
+					{ 3f, 4f, },
+				};
+				Assert.IsTrue(a.Determinent() == -2);
+			}
+			{
+				Matrix<float> a = new float[,]
+				{
+					{ 1f, 2f, 3f, },
+					{ 4f, 5f, 6f, },
+					{ 7f, 8f, 9f, },
+				};
+				Assert.IsTrue(a.Determinent() == 0);
+			}
+
+			// double
+			{
+				Matrix<double> a = new double[,]
+				{
+					{ 1d, 2d, },
+					{ 3d, 4d, },
+				};
+				Assert.IsTrue(a.Determinent() == -2);
+			}
+			{
+				Matrix<double> a = new double[,]
+				{
+					{ 1d, 2d, 3d, },
+					{ 4d, 5d, 6d, },
+					{ 7d, 8d, 9d, },
+				};
+				Assert.IsTrue(a.Determinent() == 0);
+			}
+
+			// decimal
+			{
+				Matrix<decimal> a = new decimal[,]
+				{
+					{ 1m, 2m, },
+					{ 3m, 4m, },
+				};
+				Assert.IsTrue(a.Determinent() == -2);
+			}
+			{
+				Matrix<decimal> a = new decimal[,]
+				{
+					{ 1m, 2m, 3m, },
+					{ 4m, 5m, 6m, },
+					{ 7m, 8m, 9m, },
+				};
+				Assert.IsTrue(a.Determinent() == 0);
+			}
+
+			// Exceptions
+			{
+				Matrix<decimal> a = new Matrix<decimal>(2, 3);
+				Assert.ThrowsException<MathematicsException>(() => a.Determinent());
+			}
+		}
+
+		#endregion
 
 		#region Trace
 
-		[TestMethod] public void Trace()
+		[TestMethod]
+		public void Trace()
 		{
 			// int
 			{
@@ -934,7 +933,8 @@ namespace Towel_Testing.Mathematics
 
 		#region Minor
 
-		[TestMethod] public void Minor()
+		[TestMethod]
+		public void Minor()
 		{
 			#region 2x2 Success
 			{
@@ -1080,11 +1080,11 @@ namespace Towel_Testing.Mathematics
 						{ 1, 2, },
 						{ 3, 4, },
 					};
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 0,  2));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 2,  0));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 2,  2));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 0, -2));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(-2,  0));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(0, 2));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(2, 0));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(2, 2));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(0, -2));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(-2, 0));
 					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(-2, -2));
 				}
 				// 3x3
@@ -1095,11 +1095,11 @@ namespace Towel_Testing.Mathematics
 						{ 4, 5, 6 },
 						{ 7, 8, 9 },
 					};
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 0,  3));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 3,  0));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 3,  3));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 0, -3));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(-3,  0));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(0, 3));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(3, 0));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(3, 3));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(0, -3));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(-3, 0));
 					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(-3, -3));
 				}
 			}
@@ -1110,7 +1110,8 @@ namespace Towel_Testing.Mathematics
 
 		#region ConcatenateRowWise
 
-		[TestMethod] public void ConcatenateRowWise()
+		[TestMethod]
+		public void ConcatenateRowWise()
 		{
 			{ // [2 x 2] + [2 x 2] = [2 x 4]
 				Matrix<int> A = new int[,]
@@ -1275,7 +1276,8 @@ namespace Towel_Testing.Mathematics
 
 		#region ReducedEchelon
 
-		[TestMethod] public void ReducedEchelon()
+		[TestMethod]
+		public void ReducedEchelon()
 		{
 			// int
 			{
@@ -1349,7 +1351,8 @@ namespace Towel_Testing.Mathematics
 
 		#region Inverse
 
-		[TestMethod] public void Inverse()
+		[TestMethod]
+		public void Inverse()
 		{
 			{ // float
 				Matrix<float> A = new float[,]
@@ -1387,7 +1390,8 @@ namespace Towel_Testing.Mathematics
 
 		#region Ajoint
 
-		[TestMethod] public void Ajoint()
+		[TestMethod]
+		public void Ajoint()
 		{
 			{   // int
 				Matrix<int> A = new int[,]
@@ -1455,7 +1459,8 @@ namespace Towel_Testing.Mathematics
 
 		#region Transpose
 
-		[TestMethod] public void Transpose()
+		[TestMethod]
+		public void Transpose()
 		{
 			{
 				Matrix<int> A = new int[,]
@@ -1501,7 +1506,8 @@ namespace Towel_Testing.Mathematics
 
 		#region DecomposeLowerUpper
 
-		[TestMethod] public void DecomposeLowerUpper()
+		[TestMethod]
+		public void DecomposeLowerUpper()
 		{
 			Assert.Inconclusive("Test Not Implemented");
 		}
@@ -1510,7 +1516,8 @@ namespace Towel_Testing.Mathematics
 
 		#region Rotate
 
-		[TestMethod] public void Rotate()
+		[TestMethod]
+		public void Rotate()
 		{
 			Assert.Inconclusive("Test Not Implemented");
 		}
@@ -1519,7 +1526,8 @@ namespace Towel_Testing.Mathematics
 
 		#region Equal
 
-		[TestMethod] public void Equal()
+		[TestMethod]
+		public void Equal()
 		{
 			// int
 			{
@@ -1594,7 +1602,8 @@ namespace Towel_Testing.Mathematics
 
 		#region Equal_Leniency
 
-		[TestMethod] public void Equal_Leniency()
+		[TestMethod]
+		public void Equal_Leniency()
 		{
 			// int
 			{
@@ -1754,7 +1763,8 @@ namespace Towel_Testing.Mathematics
 			public static MyFloat operator -(MyFloat a) => new MyFloat(-a.value);
 		}
 
-		[TestMethod] public void GithubIssue53()
+		[TestMethod]
+		public void GithubIssue53()
 		{
 			var a = new Matrix<MyFloat>(3, 5);
 			for (int i = 0; i < a.Rows; i++)

--- a/Tools/Towel_Testing/Mathematics/Matrix.cs
+++ b/Tools/Towel_Testing/Mathematics/Matrix.cs
@@ -10,8 +10,7 @@ namespace Towel_Testing.Mathematics
 	{
 		#region FactoryIdentity
 
-		[TestMethod]
-		public void FactoryIdentity()
+		[TestMethod] public void FactoryIdentity()
 		{
 			{ // 1 x 1
 				Matrix<int> a = Matrix<int>.FactoryIdentity(1, 1);
@@ -65,8 +64,7 @@ namespace Towel_Testing.Mathematics
 
 		#region FactoryZero
 
-		[TestMethod]
-		public void FactoryZero()
+		[TestMethod] public void FactoryZero()
 		{
 			{ // 1 x 1
 				Matrix<int> a = Matrix<int>.FactoryZero(1, 1);
@@ -121,8 +119,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Negate
 
-		[TestMethod]
-		public void Negate()
+		[TestMethod] public void Negate()
 		{
 			// int
 			{
@@ -197,8 +194,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Add
 
-		[TestMethod]
-		public void Add()
+		[TestMethod] public void Add()
 		{
 			// int
 			{
@@ -280,8 +276,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Subtract
 
-		[TestMethod]
-		public void Subtract()
+		[TestMethod] public void Subtract()
 		{
 			// int
 			{
@@ -387,8 +382,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Multiply_Matrix
 
-		[TestMethod]
-		public void Multiply_Matrix()
+		[TestMethod] public void Multiply_Matrix()
 		{
 			// int
 			{
@@ -486,8 +480,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Multiply_Vector
 
-		[TestMethod]
-		public void Multiply_Vector()
+		[TestMethod] public void Multiply_Vector()
 		{
 			// int
 			{
@@ -559,8 +552,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Multiply_Scalar
 
-		[TestMethod]
-		public void Multiply_Scalar()
+		[TestMethod] public void Multiply_Scalar()
 		{
 			// int
 			{
@@ -635,8 +627,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Divide
 
-		[TestMethod]
-		public void Divide()
+		[TestMethod] public void Divide()
 		{
 			// int
 			{
@@ -711,8 +702,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Power
 
-		[TestMethod]
-		public void Power()
+		[TestMethod] public void Power()
 		{
 			// int
 			{
@@ -785,8 +775,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Determinent
 
-		[TestMethod]
-		public void Determinent()
+		[TestMethod] public void Determinent()
 		{
 			// int 
 			{
@@ -883,8 +872,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Trace
 
-		[TestMethod]
-		public void Trace()
+		[TestMethod] public void Trace()
 		{
 			// int
 			{
@@ -941,8 +929,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Minor
 
-		[TestMethod]
-		public void Minor()
+		[TestMethod] public void Minor()
 		{
 			#region 2x2 Success
 			{
@@ -1118,8 +1105,7 @@ namespace Towel_Testing.Mathematics
 
 		#region ConcatenateRowWise
 
-		[TestMethod]
-		public void ConcatenateRowWise()
+		[TestMethod] public void ConcatenateRowWise()
 		{
 			{ // [2 x 2] + [2 x 2] = [2 x 4]
 				Matrix<int> A = new int[,]
@@ -1284,8 +1270,7 @@ namespace Towel_Testing.Mathematics
 
 		#region ReducedEchelon
 
-		[TestMethod]
-		public void ReducedEchelon()
+		[TestMethod] public void ReducedEchelon()
 		{
 			// int
 			{
@@ -1359,8 +1344,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Inverse
 
-		[TestMethod]
-		public void Inverse()
+		[TestMethod] public void Inverse()
 		{
 			{ // float
 				Matrix<float> A = new float[,]
@@ -1398,8 +1382,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Ajoint
 
-		[TestMethod]
-		public void Ajoint()
+		[TestMethod] public void Ajoint()
 		{
 			{   // int
 				Matrix<int> A = new int[,]
@@ -1467,8 +1450,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Transpose
 
-		[TestMethod]
-		public void Transpose()
+		[TestMethod] public void Transpose()
 		{
 			{
 				Matrix<int> A = new int[,]
@@ -1514,8 +1496,7 @@ namespace Towel_Testing.Mathematics
 
 		#region DecomposeLowerUpper
 
-		[TestMethod]
-		public void DecomposeLowerUpper()
+		[TestMethod] public void DecomposeLowerUpper()
 		{
 			Assert.Inconclusive("Test Not Implemented");
 		}
@@ -1524,8 +1505,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Rotate
 
-		[TestMethod]
-		public void Rotate()
+		[TestMethod] public void Rotate()
 		{
 			Assert.Inconclusive("Test Not Implemented");
 		}
@@ -1534,8 +1514,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Equal
 
-		[TestMethod]
-		public void Equal()
+		[TestMethod] public void Equal()
 		{
 			// int
 			{
@@ -1610,8 +1589,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Equal_Leniency
 
-		[TestMethod]
-		public void Equal_Leniency()
+		[TestMethod] public void Equal_Leniency()
 		{
 			// int
 			{
@@ -1771,8 +1749,7 @@ namespace Towel_Testing.Mathematics
 			public static MyFloat operator -(MyFloat a) => new MyFloat(-a.value);
 		}
 
-		[TestMethod]
-		public void GithubIssue53()
+		[TestMethod] public void GithubIssue53()
 		{
 			var a = new Matrix<MyFloat>(3, 5);
 			for (int i = 0; i < a.Rows; i++)

--- a/Tools/Towel_Testing/Mathematics/Matrix.cs
+++ b/Tools/Towel_Testing/Mathematics/Matrix.cs
@@ -775,7 +775,7 @@ namespace Towel_Testing.Mathematics
 
 		#region Determinent
 
-		[TestMethod] public void Determinent()
+		[TestMethod] public void DeterminentLaplace()
 		{
 			// int 
 			{
@@ -785,7 +785,6 @@ namespace Towel_Testing.Mathematics
 					{ 3, 4, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == -2);
-				Assert.IsTrue(a.DeterminentGaussian() == -2);
 			}
 			{
 				Matrix<int> a = new int[,]
@@ -795,9 +794,7 @@ namespace Towel_Testing.Mathematics
 					{ 7, 8, 9, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == 0);
-				Assert.IsTrue(a.DeterminentGaussian() == 0);
 			}
-
 			// float
 			{
 				Matrix<float> a = new float[,]
@@ -806,7 +803,6 @@ namespace Towel_Testing.Mathematics
 					{ 3f, 4f, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == -2);
-				Assert.IsTrue(a.DeterminentGaussian() == -2);
 			}
 			{
 				Matrix<float> a = new float[,]
@@ -816,9 +812,7 @@ namespace Towel_Testing.Mathematics
 					{ 7f, 8f, 9f, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == 0);
-				Assert.IsTrue(a.DeterminentGaussian() == 0);
 			}
-
 			// double
 			{
 				Matrix<double> a = new double[,]
@@ -827,7 +821,6 @@ namespace Towel_Testing.Mathematics
 					{ 3d, 4d, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == -2);
-				Assert.IsTrue(a.DeterminentGaussian() == -2);
 			}
 			{
 				Matrix<double> a = new double[,]
@@ -837,9 +830,7 @@ namespace Towel_Testing.Mathematics
 					{ 7d, 8d, 9d, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == 0);
-				Assert.IsTrue(a.DeterminentGaussian() == 0);
 			}
-
 			// decimal
 			{
 				Matrix<decimal> a = new decimal[,]
@@ -848,7 +839,6 @@ namespace Towel_Testing.Mathematics
 					{ 3m, 4m, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == -2);
-				Assert.IsTrue(a.DeterminentGaussian() == -2);
 			}
 			{
 				Matrix<decimal> a = new decimal[,]
@@ -858,13 +848,92 @@ namespace Towel_Testing.Mathematics
 					{ 7m, 8m, 9m, },
 				};
 				Assert.IsTrue(a.DeterminentLaplace() == 0);
-				Assert.IsTrue(a.DeterminentGaussian() == 0);
 			}
-
 			// Exceptions
 			{
 				Matrix<decimal> a = new Matrix<decimal>(2, 3);
 				Assert.ThrowsException<MathematicsException>(() => a.DeterminentLaplace());
+			}
+		}
+
+		[TestMethod] public void DeterminentGaussian()
+		{
+			// int 
+			{
+				Matrix<int> a = new int[,]
+				{
+					{ 1, 2, },
+					{ 3, 4, },
+				};
+				Assert.IsTrue(a.DeterminentGaussian() == -2);
+			}
+			{
+				Matrix<int> a = new int[,]
+				{
+					{ 1, 2, 3, },
+					{ 4, 5, 6, },
+					{ 7, 8, 9, },
+				};
+				Assert.IsTrue(a.DeterminentGaussian() == 0);
+			}
+			// float
+			{
+				Matrix<float> a = new float[,]
+				{
+					{ 1f, 2f, },
+					{ 3f, 4f, },
+				};
+				Assert.IsTrue(a.DeterminentGaussian() == -2);
+			}
+			{
+				Matrix<float> a = new float[,]
+				{
+					{ 1f, 2f, 3f, },
+					{ 4f, 5f, 6f, },
+					{ 7f, 8f, 9f, },
+				};
+				Assert.IsTrue(a.DeterminentGaussian() == 0);
+			}
+			// double
+			{
+				Matrix<double> a = new double[,]
+				{
+					{ 1d, 2d, },
+					{ 3d, 4d, },
+				};
+				Assert.IsTrue(a.DeterminentGaussian() == -2);
+			}
+			{
+				Matrix<double> a = new double[,]
+				{
+					{ 1d, 2d, 3d, },
+					{ 4d, 5d, 6d, },
+					{ 7d, 8d, 9d, },
+				};
+				Assert.IsTrue(a.DeterminentGaussian() == 0);
+			}
+			// decimal
+			{
+				Matrix<decimal> a = new decimal[,]
+				{
+					{ 1m, 2m, },
+					{ 3m, 4m, },
+				};
+				Assert.IsTrue(a.DeterminentGaussian() == -2);
+			}
+			{
+				Matrix<decimal> a = new decimal[,]
+				{
+					{ 1m, 2m, 3m, },
+					{ 4m, 5m, 6m, },
+					{ 7m, 8m, 9m, },
+				};
+				Assert.IsTrue(a.DeterminentGaussian() == 0);
+			}
+			// Exceptions
+			{
+				Matrix<decimal> a = new Matrix<decimal>(2, 3);
+				Assert.ThrowsException<MathematicsException>(() => a.DeterminentGaussian());
 			}
 		}
 

--- a/Tools/Towel_Testing/Mathematics/Matrix.cs
+++ b/Tools/Towel_Testing/Mathematics/Matrix.cs
@@ -795,7 +795,8 @@ namespace Towel_Testing.Mathematics
 					{ 1, 2, },
 					{ 3, 4, },
 				};
-				Assert.IsTrue(a.Determinent() == -2);
+				Assert.IsTrue(a.DeterminentLaplace() == -2);
+                Assert.IsTrue(a.DeterminentGaussian() == -2);
 			}
 			{
 				Matrix<int> a = new int[,]
@@ -804,7 +805,8 @@ namespace Towel_Testing.Mathematics
 					{ 4, 5, 6, },
 					{ 7, 8, 9, },
 				};
-				Assert.IsTrue(a.Determinent() == 0);
+				Assert.IsTrue(a.DeterminentLaplace() == 0);
+                Assert.IsTrue(a.DeterminentGaussian() == 0);
 			}
 
 			// float
@@ -814,7 +816,8 @@ namespace Towel_Testing.Mathematics
 					{ 1f, 2f, },
 					{ 3f, 4f, },
 				};
-				Assert.IsTrue(a.Determinent() == -2);
+				Assert.IsTrue(a.DeterminentLaplace() == -2);
+                Assert.IsTrue(a.DeterminentGaussian() == -2);
 			}
 			{
 				Matrix<float> a = new float[,]
@@ -823,7 +826,8 @@ namespace Towel_Testing.Mathematics
 					{ 4f, 5f, 6f, },
 					{ 7f, 8f, 9f, },
 				};
-				Assert.IsTrue(a.Determinent() == 0);
+				Assert.IsTrue(a.DeterminentLaplace() == 0);
+                Assert.IsTrue(a.DeterminentGaussian() == 0);
 			}
 
 			// double
@@ -833,7 +837,8 @@ namespace Towel_Testing.Mathematics
 					{ 1d, 2d, },
 					{ 3d, 4d, },
 				};
-				Assert.IsTrue(a.Determinent() == -2);
+				Assert.IsTrue(a.DeterminentLaplace() == -2);
+                Assert.IsTrue(a.DeterminentGaussian() == -2);
 			}
 			{
 				Matrix<double> a = new double[,]
@@ -842,7 +847,8 @@ namespace Towel_Testing.Mathematics
 					{ 4d, 5d, 6d, },
 					{ 7d, 8d, 9d, },
 				};
-				Assert.IsTrue(a.Determinent() == 0);
+				Assert.IsTrue(a.DeterminentLaplace() == 0);
+                Assert.IsTrue(a.DeterminentGaussian() == 0);
 			}
 
 			// decimal
@@ -852,7 +858,8 @@ namespace Towel_Testing.Mathematics
 					{ 1m, 2m, },
 					{ 3m, 4m, },
 				};
-				Assert.IsTrue(a.Determinent() == -2);
+				Assert.IsTrue(a.DeterminentLaplace() == -2);
+                Assert.IsTrue(a.DeterminentGaussian() == -2);
 			}
 			{
 				Matrix<decimal> a = new decimal[,]
@@ -861,13 +868,14 @@ namespace Towel_Testing.Mathematics
 					{ 4m, 5m, 6m, },
 					{ 7m, 8m, 9m, },
 				};
-				Assert.IsTrue(a.Determinent() == 0);
+				Assert.IsTrue(a.DeterminentLaplace() == 0);
+                Assert.IsTrue(a.DeterminentGaussian() == 0);
 			}
 
 			// Exceptions
 			{
 				Matrix<decimal> a = new Matrix<decimal>(2, 3);
-				Assert.ThrowsException<MathematicsException>(() => a.Determinent());
+				Assert.ThrowsException<MathematicsException>(() => a.DeterminentLaplace());
 			}
 		}
 

--- a/Tools/Towel_Testing/Mathematics/Matrix.cs
+++ b/Tools/Towel_Testing/Mathematics/Matrix.cs
@@ -1144,11 +1144,11 @@ namespace Towel_Testing.Mathematics
 						{ 1, 2, },
 						{ 3, 4, },
 					};
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(0, 2));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(2, 0));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(2, 2));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(0, -2));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(-2, 0));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 0,  2));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 2,  0));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 2,  2));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 0, -2));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(-2,  0));
 					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(-2, -2));
 				}
 				// 3x3
@@ -1159,11 +1159,11 @@ namespace Towel_Testing.Mathematics
 						{ 4, 5, 6 },
 						{ 7, 8, 9 },
 					};
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(0, 3));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(3, 0));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(3, 3));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(0, -3));
-					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(-3, 0));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 0,  3));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 3,  0));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 3,  3));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor( 0, -3));
+					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(-3,  0));
 					Assert.ThrowsException<ArgumentOutOfRangeException>(() => A.Minor(-3, -3));
 				}
 			}

--- a/Tools/Towel_Testing/Mathematics/Matrix.cs
+++ b/Tools/Towel_Testing/Mathematics/Matrix.cs
@@ -773,9 +773,9 @@ namespace Towel_Testing.Mathematics
 
 		#endregion
 
-		#region Determinent
+		#region Determinant
 
-		[TestMethod] public void DeterminentLaplace()
+		[TestMethod] public void DeterminantLaplace()
 		{
 			// int 
 			{
@@ -784,7 +784,7 @@ namespace Towel_Testing.Mathematics
 					{ 1, 2, },
 					{ 3, 4, },
 				};
-				Assert.IsTrue(a.DeterminentLaplace() == -2);
+				Assert.IsTrue(a.DeterminantLaplace() == -2);
 			}
 			{
 				Matrix<int> a = new int[,]
@@ -793,7 +793,7 @@ namespace Towel_Testing.Mathematics
 					{ 4, 5, 6, },
 					{ 7, 8, 9, },
 				};
-				Assert.IsTrue(a.DeterminentLaplace() == 0);
+				Assert.IsTrue(a.DeterminantLaplace() == 0);
 			}
 			// float
 			{
@@ -802,7 +802,7 @@ namespace Towel_Testing.Mathematics
 					{ 1f, 2f, },
 					{ 3f, 4f, },
 				};
-				Assert.IsTrue(a.DeterminentLaplace() == -2);
+				Assert.IsTrue(a.DeterminantLaplace() == -2);
 			}
 			{
 				Matrix<float> a = new float[,]
@@ -811,7 +811,7 @@ namespace Towel_Testing.Mathematics
 					{ 4f, 5f, 6f, },
 					{ 7f, 8f, 9f, },
 				};
-				Assert.IsTrue(a.DeterminentLaplace() == 0);
+				Assert.IsTrue(a.DeterminantLaplace() == 0);
 			}
 			// double
 			{
@@ -820,7 +820,7 @@ namespace Towel_Testing.Mathematics
 					{ 1d, 2d, },
 					{ 3d, 4d, },
 				};
-				Assert.IsTrue(a.DeterminentLaplace() == -2);
+				Assert.IsTrue(a.DeterminantLaplace() == -2);
 			}
 			{
 				Matrix<double> a = new double[,]
@@ -829,7 +829,7 @@ namespace Towel_Testing.Mathematics
 					{ 4d, 5d, 6d, },
 					{ 7d, 8d, 9d, },
 				};
-				Assert.IsTrue(a.DeterminentLaplace() == 0);
+				Assert.IsTrue(a.DeterminantLaplace() == 0);
 			}
 			// decimal
 			{
@@ -838,7 +838,7 @@ namespace Towel_Testing.Mathematics
 					{ 1m, 2m, },
 					{ 3m, 4m, },
 				};
-				Assert.IsTrue(a.DeterminentLaplace() == -2);
+				Assert.IsTrue(a.DeterminantLaplace() == -2);
 			}
 			{
 				Matrix<decimal> a = new decimal[,]
@@ -847,16 +847,16 @@ namespace Towel_Testing.Mathematics
 					{ 4m, 5m, 6m, },
 					{ 7m, 8m, 9m, },
 				};
-				Assert.IsTrue(a.DeterminentLaplace() == 0);
+				Assert.IsTrue(a.DeterminantLaplace() == 0);
 			}
 			// Exceptions
 			{
 				Matrix<decimal> a = new Matrix<decimal>(2, 3);
-				Assert.ThrowsException<MathematicsException>(() => a.DeterminentLaplace());
+				Assert.ThrowsException<MathematicsException>(() => a.DeterminantLaplace());
 			}
 		}
 
-		[TestMethod] public void DeterminentGaussian()
+		[TestMethod] public void DeterminantGaussian()
 		{
 			// int 
 			{
@@ -865,7 +865,7 @@ namespace Towel_Testing.Mathematics
 					{ 1, 2, },
 					{ 3, 4, },
 				};
-				Assert.IsTrue(a.DeterminentGaussian() == -2);
+				Assert.IsTrue(a.DeterminantGaussian() == -2);
 			}
 			{
 				Matrix<int> a = new int[,]
@@ -874,7 +874,7 @@ namespace Towel_Testing.Mathematics
 					{ 4, 5, 6, },
 					{ 7, 8, 9, },
 				};
-				Assert.IsTrue(a.DeterminentGaussian() == 0);
+				Assert.IsTrue(a.DeterminantGaussian() == 0);
 			}
 			// float
 			{
@@ -883,7 +883,7 @@ namespace Towel_Testing.Mathematics
 					{ 1f, 2f, },
 					{ 3f, 4f, },
 				};
-				Assert.IsTrue(a.DeterminentGaussian() == -2);
+				Assert.IsTrue(a.DeterminantGaussian() == -2);
 			}
 			{
 				Matrix<float> a = new float[,]
@@ -892,7 +892,7 @@ namespace Towel_Testing.Mathematics
 					{ 4f, 5f, 6f, },
 					{ 7f, 8f, 9f, },
 				};
-				Assert.IsTrue(a.DeterminentGaussian() == 0);
+				Assert.IsTrue(a.DeterminantGaussian() == 0);
 			}
 			// double
 			{
@@ -901,7 +901,7 @@ namespace Towel_Testing.Mathematics
 					{ 1d, 2d, },
 					{ 3d, 4d, },
 				};
-				Assert.IsTrue(a.DeterminentGaussian() == -2);
+				Assert.IsTrue(a.DeterminantGaussian() == -2);
 			}
 			{
 				Matrix<double> a = new double[,]
@@ -910,7 +910,7 @@ namespace Towel_Testing.Mathematics
 					{ 4d, 5d, 6d, },
 					{ 7d, 8d, 9d, },
 				};
-				Assert.IsTrue(a.DeterminentGaussian() == 0);
+				Assert.IsTrue(a.DeterminantGaussian() == 0);
 			}
 			// decimal
 			{
@@ -919,7 +919,7 @@ namespace Towel_Testing.Mathematics
 					{ 1m, 2m, },
 					{ 3m, 4m, },
 				};
-				Assert.IsTrue(a.DeterminentGaussian() == -2);
+				Assert.IsTrue(a.DeterminantGaussian() == -2);
 			}
 			{
 				Matrix<decimal> a = new decimal[,]
@@ -928,12 +928,12 @@ namespace Towel_Testing.Mathematics
 					{ 4m, 5m, 6m, },
 					{ 7m, 8m, 9m, },
 				};
-				Assert.IsTrue(a.DeterminentGaussian() == 0);
+				Assert.IsTrue(a.DeterminantGaussian() == 0);
 			}
 			// Exceptions
 			{
 				Matrix<decimal> a = new Matrix<decimal>(2, 3);
-				Assert.ThrowsException<MathematicsException>(() => a.DeterminentGaussian());
+				Assert.ThrowsException<MathematicsException>(() => a.DeterminantGaussian());
 			}
 		}
 

--- a/Tools/Towel_Testing/Mathematics/Matrix.cs
+++ b/Tools/Towel_Testing/Mathematics/Matrix.cs
@@ -5,855 +5,875 @@ using Towel.Mathematics;
 
 namespace Towel_Testing.Mathematics
 {
-	[TestClass] public class Matrix_Testing
-	{
-		#region FactoryIdentity
+    [TestClass]
+    public class Matrix_Testing
+    {
 
-		[TestMethod] public void FactoryIdentity()
+        #region FactoryIdentity
+
+        [TestMethod]
+        public void FactoryIdentity()
+        {
+            {
+                // 1 x 1
+                Matrix<int> a = Matrix<int>.FactoryIdentity(1, 1);
+                Matrix<int> b = new int[,]
+                {
+                    {1},
+                };
+                Assert.IsTrue(a == b);
+            }
+
+            {
+                // 2 x 2
+                Matrix<int> a = Matrix<int>.FactoryIdentity(2, 2);
+                Matrix<int> b = new int[,]
+                {
+                    {1, 0,},
+                    {0, 1,},
+                };
+                Assert.IsTrue(a == b);
+            }
+
+            {
+                // 3 x 3
+                Matrix<int> a = Matrix<int>.FactoryIdentity(3, 3);
+                Matrix<int> b = new int[,]
+                {
+                    {1, 0, 0,},
+                    {0, 1, 0,},
+                    {0, 0, 1,},
+                };
+                Assert.IsTrue(a == b);
+            }
+
+            {
+                // 4 x 4
+                Matrix<int> a = Matrix<int>.FactoryIdentity(4, 4);
+                Matrix<int> b = new int[,]
+                {
+                    {1, 0, 0, 0,},
+                    {0, 1, 0, 0,},
+                    {0, 0, 1, 0,},
+                    {0, 0, 0, 1,},
+                };
+            }
+
+            // Exceptions
+            {
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryIdentity(0, 1));
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryIdentity(1, 0));
+            }
+        }
+
+        #endregion
+
+        #region FactoryZero
+
+        [TestMethod]
+        public void FactoryZero()
+        {
+            {
+                // 1 x 1
+                Matrix<int> a = Matrix<int>.FactoryZero(1, 1);
+                Matrix<int> b = new int[,]
+                {
+                    {0,},
+                };
+                Assert.IsTrue(a == b);
+            }
+
+            {
+                // 2 x 2
+                Matrix<int> a = Matrix<int>.FactoryZero(2, 2);
+                Matrix<int> b = new int[,]
+                {
+                    {0, 0},
+                    {0, 0},
+                };
+                Assert.IsTrue(a == b);
+            }
+
+            {
+                // 3 x 3
+                Matrix<int> a = Matrix<int>.FactoryZero(3, 3);
+                Matrix<int> b = new int[,]
+                {
+                    {0, 0, 0},
+                    {0, 0, 0},
+                    {0, 0, 0},
+                };
+                Assert.IsTrue(a == b);
+            }
+
+            {
+                // 4 x 4
+                Matrix<int> a = Matrix<int>.FactoryZero(4, 4);
+                Matrix<int> b = new int[,]
+                {
+                    {0, 0, 0, 0},
+                    {0, 0, 0, 0},
+                    {0, 0, 0, 0},
+                    {0, 0, 0, 0},
+                };
+                Assert.IsTrue(a == b);
+            }
+
+            // Exceptions
+            {
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryZero(0, 1));
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryZero(1, 0));
+            }
+        }
+
+        #endregion
+
+        #region Negate
+
+        [TestMethod]
+        public void Negate()
+        {
+            // int
+            {
+                Matrix<int> A = new int[,]
+                {
+                    {1, 2, 3,},
+                    {4, 5, 6,},
+                    {7, 8, 9,},
+                };
+                Matrix<int> B = new int[,]
+                {
+                    {-1, -2, -3,},
+                    {-4, -5, -6,},
+                    {-7, -8, -9,},
+                };
+                Assert.IsTrue(-A == B);
+            }
+
+            // float
+            {
+                Matrix<float> A = new float[,]
+                {
+                    {1f, 2f, 3f,},
+                    {4f, 5f, 6f,},
+                    {7f, 8f, 9f,},
+                };
+                Matrix<float> B = new float[,]
+                {
+                    {-1f, -2f, -3f,},
+                    {-4f, -5f, -6f,},
+                    {-7f, -8f, -9f,},
+                };
+                Assert.IsTrue(-A == B);
+            }
+
+            // double
+            {
+                Matrix<double> A = new double[,]
+                {
+                    {1d, 2d, 3d,},
+                    {4d, 5d, 6d,},
+                    {7d, 8d, 9d,},
+                };
+                Matrix<double> B = new double[,]
+                {
+                    {-1d, -2d, -3d,},
+                    {-4d, -5d, -6d,},
+                    {-7d, -8d, -9d,},
+                };
+                Assert.IsTrue(-A == B);
+            }
+
+            // decimal
+            {
+                Matrix<decimal> A = new decimal[,]
+                {
+                    {1m, 2m, 3m,},
+                    {4m, 5m, 6m,},
+                    {7m, 8m, 9m,},
+                };
+                Matrix<decimal> B = new decimal[,]
+                {
+                    {-1m, -2m, -3m,},
+                    {-4m, -5m, -6m,},
+                    {-7m, -8m, -9m,},
+                };
+                Assert.IsTrue(-A == B);
+            }
+        }
+
+        #endregion
+
+        #region Add
+
+        [TestMethod]
+        public void Add()
+        {
+            // int
+            {
+                Matrix<int> A = new int[,]
+                {
+                    {1, 2, 3,},
+                    {4, 5, 6,},
+                    {7, 8, 9,},
+                };
+                Matrix<int> B = new int[,]
+                {
+                    {2, 4, 6,},
+                    {8, 10, 12,},
+                    {14, 16, 18,},
+                };
+                Assert.IsTrue(A + A == B);
+            }
+
+            // float
+            {
+                Matrix<float> A = new float[,]
+                {
+                    {1f, 2f, 3f,},
+                    {4f, 5f, 6f,},
+                    {7f, 8f, 9f,},
+                };
+                Matrix<float> B = new float[,]
+                {
+                    {2f, 4f, 6f,},
+                    {8f, 10f, 12f,},
+                    {14f, 16f, 18f,},
+                };
+                Assert.IsTrue(A + A == B);
+            }
+
+            // double
+            {
+                Matrix<double> A = new double[,]
+                {
+                    {1d, 2d, 3d,},
+                    {4d, 5d, 6d,},
+                    {7d, 8d, 9d,},
+                };
+                Matrix<double> B = new double[,]
+                {
+                    {2d, 4d, 6d,},
+                    {8d, 10d, 12d,},
+                    {14d, 16d, 18d,},
+                };
+                Assert.IsTrue(A + A == B);
+            }
+
+            // decimal
+            {
+                Matrix<decimal> A = new decimal[,]
+                {
+                    {1m, 2m, 3m,},
+                    {4m, 5m, 6m,},
+                    {7m, 8m, 9m,},
+                };
+                Matrix<decimal> B = new decimal[,]
+                {
+                    {2m, 4m, 6m,},
+                    {8m, 10m, 12m,},
+                    {14m, 16m, 18m,},
+                };
+                Assert.IsTrue(A + A == B);
+            }
+
+            // Exceptions
+            {
+                Matrix<decimal> A = new Matrix<decimal>(2, 2);
+                Matrix<decimal> B = new Matrix<decimal>(3, 3);
+                Assert.ThrowsException<MathematicsException>(() => A + B);
+            }
+        }
+
+        #endregion
+
+        #region Subtract
+
+        [TestMethod]
+        public void Subtract()
+        {
+            // int
+            {
+                Matrix<int> A = new int[,]
+                {
+                    {3, 5, 7,},
+                    {9, 11, 13,},
+                    {15, 17, 19,},
+                };
+                Matrix<int> B = new int[,]
+                {
+                    {2, 3, 4,},
+                    {5, 6, 7,},
+                    {8, 9, 10,},
+                };
+                Matrix<int> C = new int[,]
+                {
+                    {1, 2, 3,},
+                    {4, 5, 6,},
+                    {7, 8, 9,},
+                };
+                Assert.IsTrue(A - B == C);
+            }
+
+            // float
+            {
+                Matrix<float> A = new float[,]
+                {
+                    {3f, 5f, 7f,},
+                    {9f, 11f, 13f,},
+                    {15f, 17f, 19f,},
+                };
+                Matrix<float> B = new float[,]
+                {
+                    {2f, 3f, 4f,},
+                    {5f, 6f, 7f,},
+                    {8f, 9f, 10f,},
+                };
+                Matrix<float> C = new float[,]
+                {
+                    {1f, 2f, 3f,},
+                    {4f, 5f, 6f,},
+                    {7f, 8f, 9f,},
+                };
+                Assert.IsTrue(A - B == C);
+            }
+
+            // double
+            {
+                Matrix<double> A = new double[,]
+                {
+                    {3d, 5d, 7d,},
+                    {9d, 11d, 13d,},
+                    {15d, 17d, 19d,},
+                };
+                Matrix<double> B = new double[,]
+                {
+                    {2d, 3d, 4d,},
+                    {5d, 6d, 7d,},
+                    {8d, 9d, 10d,},
+                };
+                Matrix<double> C = new double[,]
+                {
+                    {1d, 2d, 3d,},
+                    {4d, 5d, 6d,},
+                    {7d, 8d, 9d,},
+                };
+                Assert.IsTrue(A - B == C);
+            }
+
+            // decimal
+            {
+                Matrix<decimal> A = new decimal[,]
+                {
+                    {3m, 5m, 7m,},
+                    {9m, 11m, 13m,},
+                    {15m, 17m, 19m,},
+                };
+                Matrix<decimal> B = new decimal[,]
+                {
+                    {2m, 3m, 4m,},
+                    {5m, 6m, 7m,},
+                    {8m, 9m, 10m,},
+                };
+                Matrix<decimal> C = new decimal[,]
+                {
+                    {1m, 2m, 3m,},
+                    {4m, 5m, 6m,},
+                    {7m, 8m, 9m,},
+                };
+                Assert.IsTrue(A - B == C);
+            }
+
+            // Exceptions
+            {
+                Matrix<decimal> A = new Matrix<decimal>(2, 2);
+                Matrix<decimal> B = new Matrix<decimal>(3, 3);
+                Assert.ThrowsException<MathematicsException>(() => A - B);
+            }
+        }
+
+        #endregion
+
+        #region Multiply_Matrix
+
+        [TestMethod]
+        public void Multiply_Matrix()
+        {
+            // int
+            {
+                Matrix<int> A = new int[,]
+                {
+                    {1, 2, 3,},
+                    {4, 5, 6,},
+                };
+                Matrix<int> B = new int[,]
+                {
+                    {7, 8,},
+                    {9, 10,},
+                    {11, 12,},
+                };
+                Matrix<int> C = new int[,]
+                {
+                    {58, 64,},
+                    {139, 154,},
+                };
+                Assert.IsTrue(A * B == C);
+            }
+
+            // float
+            {
+                Matrix<float> A = new float[,]
+                {
+                    {1f, 2f, 3f,},
+                    {4f, 5f, 6f,},
+                };
+                Matrix<float> B = new float[,]
+                {
+                    {7f, 8f,},
+                    {9f, 10f,},
+                    {11f, 12f,},
+                };
+                Matrix<float> C = new float[,]
+                {
+                    {58f, 64f,},
+                    {139f, 154f,},
+                };
+                Assert.IsTrue(A * B == C);
+            }
+
+            // double
+            {
+                Matrix<double> A = new double[,]
+                {
+                    {1d, 2d, 3d,},
+                    {4d, 5d, 6d,},
+                };
+                Matrix<double> B = new double[,]
+                {
+                    {7d, 8d,},
+                    {9d, 10d,},
+                    {11d, 12d,},
+                };
+                Matrix<double> C = new double[,]
+                {
+                    {58d, 64d,},
+                    {139d, 154d,},
+                };
+                Assert.IsTrue(A * B == C);
+            }
+
+            // decimal
+            {
+                Matrix<decimal> A = new decimal[,]
+                {
+                    {1m, 2m, 3m,},
+                    {4m, 5m, 6m,},
+                };
+                Matrix<decimal> B = new decimal[,]
+                {
+                    {7m, 8m,},
+                    {9m, 10m,},
+                    {11m, 12m,},
+                };
+                Matrix<decimal> C = new decimal[,]
+                {
+                    {58m, 64m,},
+                    {139m, 154m,},
+                };
+                Assert.IsTrue(A * B == C);
+            }
+
+            // Exceptions
+            {
+                Matrix<decimal> A = new Matrix<decimal>(2, 2);
+                Matrix<decimal> B = new Matrix<decimal>(3, 3);
+                Assert.ThrowsException<MathematicsException>(() => A * B);
+            }
+        }
+
+        #endregion
+
+        #region Multiply_Vector
+
+        [TestMethod]
+        public void Multiply_Vector()
+        {
+            // int
+            {
+                Matrix<int> A = new Matrix<int>(3, 3)
+                {
+                    [0] = 2, [1] = 3, [2] = -4,
+                    [3] = 11, [4] = 8, [5] = 7,
+                    [6] = 2, [7] = 5, [8] = 3,
+                };
+                Vector<int> B = new Vector<int>(3, 7, 5);
+                Vector<int> C = new Vector<int>(7, 124, 56);
+                Assert.IsTrue(A * B == C);
+            }
+
+            // float
+            {
+                Matrix<float> A = new float[,]
+                {
+                    {2f, 3f, -4f,},
+                    {11f, 8f, 7f,},
+                    {2f, 5f, 3f,},
+                };
+                Vector<float> B = new Vector<float>(3, 7, 5);
+                Vector<float> C = new Vector<float>(7, 124, 56);
+                Assert.IsTrue(A * B == C);
+            }
+
+            // double
+            {
+                Matrix<double> A = new double[,]
+                {
+                    {2d, 3d, -4d,},
+                    {11d, 8d, 7d,},
+                    {2d, 5d, 3d,},
+                };
+                Vector<double> B = new Vector<double>(3d, 7d, 5d);
+                Vector<double> C = new Vector<double>(7d, 124d, 56d);
+                Assert.IsTrue(A * B == C);
+            }
+
+            // decimal
+            {
+                Matrix<decimal> A = new decimal[,]
+                {
+                    {2m, 3m, -4m,},
+                    {11m, 8m, 7m,},
+                    {2m, 5m, 3m,},
+                };
+                Vector<decimal> B = new Vector<decimal>(3m, 7m, 5m);
+                Vector<decimal> C = new Vector<decimal>(7m, 124m, 56m);
+                Assert.IsTrue(A * B == C);
+            }
+
+            // Exceptions
+            {
+                Vector<int> V = new Vector<int>(1);
+                Matrix<int> M = new Matrix<int>(2, 2);
+                Assert.ThrowsException<MathematicsException>(() => M * V);
+            }
+        }
+
+        #endregion
+
+        #region Multiply_Scalar
+
+        [TestMethod]
+        public void Multiply_Scalar()
+        {
+            // int
+            {
+                Matrix<int> A = new int[,]
+                {
+                    {1, 2, 3,},
+                    {4, 5, 6,},
+                    {7, 8, 9,},
+                };
+                Matrix<int> B = new int[,]
+                {
+                    {2, 4, 6,},
+                    {8, 10, 12,},
+                    {14, 16, 18,},
+                };
+                Assert.IsTrue(A * 2 == B);
+            }
+
+            // float
+            {
+                Matrix<float> A = new float[,]
+                {
+                    {1f, 2f, 3f,},
+                    {4f, 5f, 6f,},
+                    {7f, 8f, 9f,},
+                };
+                Matrix<float> B = new float[,]
+                {
+                    {2f, 4f, 6f,},
+                    {8f, 10f, 12f,},
+                    {14f, 16f, 18f,},
+                };
+                Assert.IsTrue(A * 2f == B);
+            }
+
+            // double
+            {
+                Matrix<double> A = new double[,]
+                {
+                    {1d, 2d, 3d,},
+                    {4d, 5d, 6d,},
+                    {7d, 8d, 9d,},
+                };
+                Matrix<double> B = new double[,]
+                {
+                    {2d, 4d, 6d,},
+                    {8d, 10d, 12d,},
+                    {14d, 16d, 18d,},
+                };
+                Assert.IsTrue(A * 2d == B);
+            }
+
+            // decimal
+            {
+                Matrix<decimal> A = new decimal[,]
+                {
+                    {1m, 2m, 3m,},
+                    {4m, 5m, 6m,},
+                    {7m, 8m, 9m,},
+                };
+                Matrix<decimal> B = new decimal[,]
+                {
+                    {2m, 4m, 6m,},
+                    {8m, 10m, 12m,},
+                    {14m, 16m, 18m,},
+                };
+                Assert.IsTrue(A * 2m == B);
+            }
+        }
+
+        #endregion
+
+        #region Divide
+
+        [TestMethod]
+        public void Divide()
+        {
+            // int
+            {
+                Matrix<int> A = new int[,]
+                {
+                    {2, 4, 6,},
+                    {8, 10, 12,},
+                    {14, 16, 18,},
+                };
+                Matrix<int> B = new int[,]
+                {
+                    {1, 2, 3,},
+                    {4, 5, 6,},
+                    {7, 8, 9,},
+                };
+                Assert.IsTrue(A / 2 == B);
+            }
+
+            // float
+            {
+                Matrix<float> A = new float[,]
+                {
+                    {2f, 4f, 6f,},
+                    {8f, 10f, 12f,},
+                    {14f, 16f, 18f,},
+                };
+                Matrix<float> B = new float[,]
+                {
+                    {1f, 2f, 3f,},
+                    {4f, 5f, 6f,},
+                    {7f, 8f, 9f,},
+                };
+                Assert.IsTrue(A / 2f == B);
+            }
+
+            // double
+            {
+                Matrix<double> A = new double[,]
+                {
+                    {2d, 4d, 6d,},
+                    {8d, 10d, 12d,},
+                    {14d, 16d, 18d,},
+                };
+                Matrix<double> B = new double[,]
+                {
+                    {1d, 2d, 3d,},
+                    {4d, 5d, 6d,},
+                    {7d, 8d, 9d,},
+                };
+                Assert.IsTrue(A / 2d == B);
+            }
+
+            // decimal
+            {
+                Matrix<decimal> A = new decimal[,]
+                {
+                    {2m, 4m, 6m,},
+                    {8m, 10m, 12m,},
+                    {14m, 16m, 18m,},
+                };
+                Matrix<decimal> B = new decimal[,]
+                {
+                    {1m, 2m, 3m,},
+                    {4m, 5m, 6m,},
+                    {7m, 8m, 9m,},
+                };
+                Assert.IsTrue(A / 2m == B);
+            }
+        }
+
+        #endregion
+
+        #region Power
+
+        [TestMethod]
+        public void Power()
+        {
+            // int
+            {
+                Matrix<int> A = new int[,]
+                {
+                    {1, 2,},
+                    {3, 4,},
+                };
+                Matrix<int> B = new int[,]
+                {
+                    {37, 54,},
+                    {81, 118,},
+                };
+                Assert.IsTrue((A ^ 3) == B);
+            }
+
+            // float
+            {
+                Matrix<float> A = new float[,]
+                {
+                    {1f, 2f,},
+                    {3f, 4f,},
+                };
+                Matrix<float> B = new float[,]
+                {
+                    {37f, 54f,},
+                    {81f, 118f,},
+                };
+                Assert.IsTrue((A ^ 3) == B);
+            }
+
+            // double
+            {
+                Matrix<double> A = new double[,]
+                {
+                    {1d, 2d,},
+                    {3d, 4d,},
+                };
+                Matrix<double> B = new double[,]
+                {
+                    {37d, 54d,},
+                    {81d, 118d,},
+                };
+                Assert.IsTrue((A ^ 3) == B);
+            }
+
+            // decimal
+            {
+                Matrix<decimal> A = new decimal[,]
+                {
+                    {1m, 2m,},
+                    {3m, 4m,},
+                };
+                Matrix<decimal> B = new decimal[,]
+                {
+                    {37m, 54m,},
+                    {81m, 118m,},
+                };
+                Assert.IsTrue((A ^ 3) == B);
+            }
+
+            // Exceptions
+            {
+                Matrix<decimal> A = new Matrix<decimal>(2, 3);
+                Assert.ThrowsException<MathematicsException>(() => A ^ 3);
+            }
+        }
+
+        #endregion
+
+        #region Determinent
+
+        public void CheckDet<T>(T[,] data, T expected)
+        {
+            Matrix<T> a = data;
+            var actual = a.Determinent();
+            var error = Syntax.AbsoluteValue(Syntax.Subtraction(actual, expected));
+            Assert.IsTrue(Syntax.LessThan(error, Syntax.Convert<float, T>(0.1f)) || Syntax.Comparison(error, Constant<T>.Zero) == CompareResult.Equal,
+				$"actual: {actual}  expected: {expected}  error: {error}");
+        }
+
+        [TestMethod]
+        public void DeterminentInt1()
+        => CheckDet(new int[,]
+            {
+                {1, 2,},
+                {3, 4,},
+            }, -2);
+
+        [TestMethod]
+        public void DeterminentInt2()
+            => CheckDet(new int[,]
+                {
+                    {1, 2, 3,},
+                    {4, 5, 6,},
+                    {7, 8, 9,},
+                }, 0);
+
+        [TestMethod]
+        public void DeterminentFloat1()
+        => CheckDet(new float[,]
+            {
+                {1f, 2f,},
+                {3f, 4f,},
+            }, -2);
+
+        [TestMethod]
+        public void DeterminentFloat2()
+            => CheckDet(new float[,]
+            {
+                {1f, 2f, 3f,},
+                {4f, 5f, 6f,},
+                {7f, 8f, 9f,},
+            }, 0);
+
+
+        [TestMethod]
+        public void DeterminentDouble1()
+        => CheckDet(new double[,]
+            {
+                {1d, 2d,},
+                {3d, 4d,},
+            }, -2);
+
+        [TestMethod]
+        public void DeterminentDouble2()
+            => CheckDet(new double[,]
+            {
+                {1d, 2d, 3d,},
+                {4d, 5d, 6d,},
+                {7d, 8d, 9d,},
+            }, 0);
+
+        [TestMethod]
+        public void DeterminentDecimal1()
+            => CheckDet(new decimal[,]
+            {
+                {1m, 2m,},
+                {3m, 4m,},
+            }, -2);
+
+        [TestMethod]
+        public void DeterminentDecimal2()
+            => CheckDet(new decimal[,]
+                {
+                    {1m, 2m, 3m,},
+                    {4m, 5m, 6m,},
+                    {7m, 8m, 9m,},
+                }, 0);
+
+        [TestMethod]
+        public void DeterminentException()
 		{
-			{ // 1 x 1
-				Matrix<int> a = Matrix<int>.FactoryIdentity(1, 1);
-				Matrix<int> b = new int[,]
-				{
-					{ 1 },
-				};
-				Assert.IsTrue(a == b);
-			}
-
-			{ // 2 x 2
-				Matrix<int> a = Matrix<int>.FactoryIdentity(2, 2);
-				Matrix<int> b = new int[,]
-				{
-					{ 1, 0, },
-					{ 0, 1, },
-				};
-				Assert.IsTrue(a == b);
-			}
-
-			{ // 3 x 3
-				Matrix<int> a = Matrix<int>.FactoryIdentity(3, 3);
-				Matrix<int> b = new int[,]
-				{
-					{ 1, 0, 0, },
-					{ 0, 1, 0, },
-					{ 0, 0, 1, },
-				};
-				Assert.IsTrue(a == b);
-			}
-
-			{ // 4 x 4
-				Matrix<int> a = Matrix<int>.FactoryIdentity(4, 4);
-				Matrix<int> b = new int[,]
-				{
-					{ 1, 0, 0, 0, },
-					{ 0, 1, 0, 0, },
-					{ 0, 0, 1, 0, },
-					{ 0, 0, 0, 1, },
-				};
-			}
-
-			// Exceptions
-			{
-				Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryIdentity(0, 1));
-				Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryIdentity(1, 0));
-			}
+			Matrix<decimal> a = new Matrix<decimal>(2, 3);
+			Assert.ThrowsException<MathematicsException>(() => a.Determinent());
 		}
 
-		#endregion
-
-		#region FactoryZero
-
-		[TestMethod] public void FactoryZero()
-		{
-			{ // 1 x 1
-				Matrix<int> a = Matrix<int>.FactoryZero(1, 1);
-				Matrix<int> b = new int[,]
-				{
-					{ 0, },
-				};
-				Assert.IsTrue(a == b);
-			}
-
-			{ // 2 x 2
-				Matrix<int> a = Matrix<int>.FactoryZero(2, 2);
-				Matrix<int> b = new int[,]
-				{
-					{ 0, 0 },
-					{ 0, 0 },
-				};
-				Assert.IsTrue(a == b);
-			}
-
-			{ // 3 x 3
-				Matrix<int> a = Matrix<int>.FactoryZero(3, 3);
-				Matrix<int> b = new int[,]
-				{
-					{ 0, 0, 0 },
-					{ 0, 0, 0 },
-					{ 0, 0, 0 },
-				};
-				Assert.IsTrue(a == b);
-			}
-
-			{ // 4 x 4
-				Matrix<int> a = Matrix<int>.FactoryZero(4, 4);
-				Matrix<int> b = new int[,]
-				{
-					{ 0, 0, 0, 0 },
-					{ 0, 0, 0, 0 },
-					{ 0, 0, 0, 0 },
-					{ 0, 0, 0, 0 },
-				};
-				Assert.IsTrue(a == b);
-			}
-
-			// Exceptions
-			{
-				Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryZero(0, 1));
-				Assert.ThrowsException<ArgumentOutOfRangeException>(() => Matrix<int>.FactoryZero(1, 0));
-			}
-		}
-
-		#endregion
-
-		#region Negate
-
-		[TestMethod] public void Negate()
-		{
-			// int
-			{
-				Matrix<int> A = new int[,]
-				{
-					{ 1, 2, 3, },
-					{ 4, 5, 6, },
-					{ 7, 8, 9, },
-				};
-				Matrix<int> B = new int[,]
-				{
-					{ -1, -2, -3, },
-					{ -4, -5, -6, },
-					{ -7, -8, -9, },
-				};
-				Assert.IsTrue(-A == B);
-			}
-
-			// float
-			{
-				Matrix<float> A = new float[,]
-				{
-					{ 1f, 2f, 3f, },
-					{ 4f, 5f, 6f, },
-					{ 7f, 8f, 9f, },
-				};
-				Matrix<float> B = new float[,]
-				{
-					{ -1f, -2f, -3f, },
-					{ -4f, -5f, -6f, },
-					{ -7f, -8f, -9f, },
-				};
-				Assert.IsTrue(-A == B);
-			}
-
-			// double
-			{
-				Matrix<double> A = new double[,]
-				{
-					{ 1d, 2d, 3d, },
-					{ 4d, 5d, 6d, },
-					{ 7d, 8d, 9d, },
-				};
-				Matrix<double> B = new double[,]
-				{
-					{ -1d, -2d, -3d, },
-					{ -4d, -5d, -6d, },
-					{ -7d, -8d, -9d, },
-				};
-				Assert.IsTrue(-A == B);
-			}
-
-			// decimal
-			{
-				Matrix<decimal> A = new decimal[,]
-				{
-					{ 1m, 2m, 3m, },
-					{ 4m, 5m, 6m, },
-					{ 7m, 8m, 9m, },
-				};
-				Matrix<decimal> B = new decimal[,]
-				{
-					{ -1m, -2m, -3m, },
-					{ -4m, -5m, -6m, },
-					{ -7m, -8m, -9m, },
-				};
-				Assert.IsTrue(-A == B);
-			}
-		}
-
-		#endregion
-
-		#region Add
-
-		[TestMethod] public void Add()
-		{
-			// int
-			{
-				Matrix<int> A = new int[,]
-				{
-					{ 1, 2, 3, },
-					{ 4, 5, 6, },
-					{ 7, 8, 9, },
-				};
-				Matrix<int> B = new int[,]
-				{
-					{  2,  4,  6, },
-					{  8, 10, 12, },
-					{ 14, 16, 18, },
-				};
-				Assert.IsTrue(A + A == B);
-			}
-
-			// float
-			{
-				Matrix<float> A = new float[,]
-				{
-					{ 1f, 2f, 3f, },
-					{ 4f, 5f, 6f, },
-					{ 7f, 8f, 9f, },
-				};
-				Matrix<float> B = new float[,]
-				{
-					{  2f,  4f,  6f, },
-					{  8f, 10f, 12f, },
-					{ 14f, 16f, 18f, },
-				};
-				Assert.IsTrue(A + A == B);
-			}
-
-			// double
-			{
-				Matrix<double> A = new double[,]
-				{
-					{ 1d, 2d, 3d, },
-					{ 4d, 5d, 6d, },
-					{ 7d, 8d, 9d, },
-				};
-				Matrix<double> B = new double[,]
-				{
-					{  2d,  4d,  6d, },
-					{  8d, 10d, 12d, },
-					{ 14d, 16d, 18d, },
-				};
-				Assert.IsTrue(A + A == B);
-			}
-
-			// decimal
-			{
-				Matrix<decimal> A = new decimal[,]
-				{
-					{ 1m, 2m, 3m, },
-					{ 4m, 5m, 6m, },
-					{ 7m, 8m, 9m, },
-				};
-				Matrix<decimal> B = new decimal[,]
-				{
-					{  2m,  4m,  6m, },
-					{  8m, 10m, 12m, },
-					{ 14m, 16m, 18m, },
-				};
-				Assert.IsTrue(A + A == B);
-			}
-
-			// Exceptions
-			{
-				Matrix<decimal> A = new Matrix<decimal>(2, 2);
-				Matrix<decimal> B = new Matrix<decimal>(3, 3);
-				Assert.ThrowsException<MathematicsException>(() => A + B);
-			}
-		}
-
-		#endregion
-
-		#region Subtract
-
-		[TestMethod] public void Subtract()
-		{
-			// int
-			{
-				Matrix<int> A = new int[,]
-				{
-					{  3,  5,  7, },
-					{  9, 11, 13, },
-					{ 15, 17, 19, },
-				};
-				Matrix<int> B = new int[,]
-				{
-					{ 2, 3,  4, },
-					{ 5, 6,  7, },
-					{ 8, 9, 10, },
-				};
-				Matrix<int> C = new int[,]
-				{
-					{ 1, 2, 3, },
-					{ 4, 5, 6, },
-					{ 7, 8, 9, },
-				};
-				Assert.IsTrue(A - B == C);
-			}
-
-			// float
-			{
-				Matrix<float> A = new float[,]
-				{
-					{  3f,  5f,  7f, },
-					{  9f, 11f, 13f, },
-					{ 15f, 17f, 19f, },
-				};
-				Matrix<float> B = new float[,]
-				{
-					{ 2f, 3f,  4f, },
-					{ 5f, 6f,  7f, },
-					{ 8f, 9f, 10f, },
-				};
-				Matrix<float> C = new float[,]
-				{
-					{ 1f, 2f, 3f, },
-					{ 4f, 5f, 6f, },
-					{ 7f, 8f, 9f, },
-				};
-				Assert.IsTrue(A - B == C);
-			}
-
-			// double
-			{
-				Matrix<double> A = new double[,]
-				{
-					{  3d,  5d,  7d, },
-					{  9d, 11d, 13d, },
-					{ 15d, 17d, 19d, },
-				};
-				Matrix<double> B = new double[,]
-				{
-					{ 2d, 3d,  4d, },
-					{ 5d, 6d,  7d, },
-					{ 8d, 9d, 10d, },
-				};
-				Matrix<double> C = new double[,]
-				{
-					{ 1d, 2d, 3d, },
-					{ 4d, 5d, 6d, },
-					{ 7d, 8d, 9d, },
-				};
-				Assert.IsTrue(A - B == C);
-			}
-
-			// decimal
-			{
-				Matrix<decimal> A = new decimal[,]
-				{
-					{  3m,  5m,  7m, },
-					{  9m, 11m, 13m, },
-					{ 15m, 17m, 19m, },
-				};
-				Matrix<decimal> B = new decimal[,]
-				{
-					{ 2m, 3m,  4m, },
-					{ 5m, 6m,  7m, },
-					{ 8m, 9m, 10m, },
-				};
-				Matrix<decimal> C = new decimal[,]
-				{
-					{ 1m, 2m, 3m, },
-					{ 4m, 5m, 6m, },
-					{ 7m, 8m, 9m, },
-				};
-				Assert.IsTrue(A - B == C);
-			}
-
-			// Exceptions
-			{
-				Matrix<decimal> A = new Matrix<decimal>(2, 2);
-				Matrix<decimal> B = new Matrix<decimal>(3, 3);
-				Assert.ThrowsException<MathematicsException>(() => A - B);
-			}
-		}
-
-		#endregion
-
-		#region Multiply_Matrix
-
-		[TestMethod] public void Multiply_Matrix()
-		{
-			// int
-			{
-				Matrix<int> A = new int[,]
-				{
-					{ 1, 2, 3, },
-					{ 4, 5, 6, },
-				};
-				Matrix<int> B = new int[,]
-				{
-					{  7,  8, },
-					{  9, 10, },
-					{ 11, 12, },
-				};
-				Matrix<int> C = new int[,]
-				{
-					{  58,  64, },
-					{ 139, 154, },
-				};
-				Assert.IsTrue(A * B == C);
-			}
-
-			// float
-			{
-				Matrix<float> A = new float[,]
-				{
-					{ 1f, 2f, 3f, },
-					{ 4f, 5f, 6f, },
-				};
-				Matrix<float> B = new float[,]
-				{
-					{  7f,  8f, },
-					{  9f, 10f, },
-					{ 11f, 12f, },
-				};
-				Matrix<float> C = new float[,]
-				{
-					{  58f,  64f, },
-					{ 139f, 154f, },
-				};
-				Assert.IsTrue(A * B == C);
-			}
-
-			// double
-			{
-				Matrix<double> A = new double[,]
-				{
-					{ 1d, 2d, 3d, },
-					{ 4d, 5d, 6d, },
-				};
-				Matrix<double> B = new double[,]
-				{
-					{  7d,  8d, },
-					{  9d, 10d, },
-					{ 11d, 12d, },
-				};
-				Matrix<double> C = new double[,]
-				{
-					{  58d,  64d, },
-					{ 139d, 154d, },
-				};
-				Assert.IsTrue(A * B == C);
-			}
-
-			// decimal
-			{
-				Matrix<decimal> A = new decimal[,]
-				{
-					{ 1m, 2m, 3m, },
-					{ 4m, 5m, 6m, },
-				};
-				Matrix<decimal> B = new decimal[,]
-				{
-					{  7m,  8m, },
-					{  9m, 10m, },
-					{ 11m, 12m, },
-				};
-				Matrix<decimal> C = new decimal[,]
-				{
-					{  58m,  64m, },
-					{ 139m, 154m, },
-				};
-				Assert.IsTrue(A * B == C);
-			}
-
-			// Exceptions
-			{
-				Matrix<decimal> A = new Matrix<decimal>(2, 2);
-				Matrix<decimal> B = new Matrix<decimal>(3, 3);
-				Assert.ThrowsException<MathematicsException>(() => A * B);
-			}
-		}
-
-		#endregion
-
-		#region Multiply_Vector
-
-		[TestMethod] public void Multiply_Vector()
-		{
-			// int
-			{
-				Matrix<int> A = new Matrix<int>(3, 3)
-				{
-					[0] =  2, [1] = 3, [2] = -4,
-					[3] = 11, [4] = 8, [5] =  7,
-					[6] =  2, [7] = 5, [8] =  3,
-				};
-				Vector<int> B = new Vector<int>(3, 7, 5);
-				Vector<int> C = new Vector<int>(7, 124, 56);
-				Assert.IsTrue(A * B == C);
-			}
-
-			// float
-			{
-				Matrix<float> A = new float[,]
-				{
-					{  2f, 3f, -4f, },
-					{ 11f, 8f,  7f, },
-					{  2f, 5f,  3f, },
-				};
-				Vector<float> B = new Vector<float>(3, 7, 5);
-				Vector<float> C = new Vector<float>(7, 124, 56);
-				Assert.IsTrue(A * B == C);
-			}
-
-			// double
-			{
-				Matrix<double> A = new double[,]
-				{
-					{  2d, 3d, -4d, },
-					{ 11d, 8d,  7d, },
-					{  2d, 5d,  3d, },
-				};
-				Vector<double> B = new Vector<double>(3d, 7d, 5d);
-				Vector<double> C = new Vector<double>(7d, 124d, 56d);
-				Assert.IsTrue(A * B == C);
-			}
-
-			// decimal
-			{
-				Matrix<decimal> A = new decimal[,]
-				{
-					{  2m, 3m, -4m, },
-					{ 11m, 8m,  7m, },
-					{  2m, 5m,  3m, },
-				};
-				Vector<decimal> B = new Vector<decimal>(3m, 7m, 5m);
-				Vector<decimal> C = new Vector<decimal>(7m, 124m, 56m);
-				Assert.IsTrue(A * B == C);
-			}
-
-			// Exceptions
-			{
-				Vector<int> V = new Vector<int>(1);
-				Matrix<int> M = new Matrix<int>(2, 2);
-				Assert.ThrowsException<MathematicsException>(() => M * V);
-			}
-		}
-
-		#endregion
-
-		#region Multiply_Scalar
-
-		[TestMethod] public void Multiply_Scalar()
-		{
-			// int
-			{
-				Matrix<int> A = new int[,]
-				{
-					{ 1, 2, 3, },
-					{ 4, 5, 6, },
-					{ 7, 8, 9, },
-				};
-				Matrix<int> B = new int[,]
-				{
-					{  2,  4,  6, },
-					{  8, 10, 12, },
-					{ 14, 16, 18, },
-				};
-				Assert.IsTrue(A * 2 == B);
-			}
-
-			// float
-			{
-				Matrix<float> A = new float[,]
-				{
-					{ 1f, 2f, 3f, },
-					{ 4f, 5f, 6f, },
-					{ 7f, 8f, 9f, },
-				};
-				Matrix<float> B = new float[,]
-				{
-					{  2f,  4f,  6f, },
-					{  8f, 10f, 12f, },
-					{ 14f, 16f, 18f, },
-				};
-				Assert.IsTrue(A * 2f == B);
-			}
-
-			// double
-			{
-				Matrix<double> A = new double[,]
-				{
-					{ 1d, 2d, 3d, },
-					{ 4d, 5d, 6d, },
-					{ 7d, 8d, 9d, },
-				};
-				Matrix<double> B = new double[,]
-				{
-					{  2d,  4d,  6d, },
-					{  8d, 10d, 12d, },
-					{ 14d, 16d, 18d, },
-				};
-				Assert.IsTrue(A * 2d == B);
-			}
-
-			// decimal
-			{
-				Matrix<decimal> A = new decimal[,]
-				{
-					{ 1m, 2m, 3m, },
-					{ 4m, 5m, 6m, },
-					{ 7m, 8m, 9m, },
-				};
-				Matrix<decimal> B = new decimal[,]
-				{
-					{  2m,  4m,  6m, },
-					{  8m, 10m, 12m, },
-					{ 14m, 16m, 18m, },
-				};
-				Assert.IsTrue(A * 2m == B);
-			}
-		}
-
-		#endregion
-
-		#region Divide
-
-		[TestMethod] public void Divide()
-		{
-			// int
-			{
-				Matrix<int> A = new int[,]
-				{
-					{  2,  4,  6, },
-					{  8, 10, 12, },
-					{ 14, 16, 18, },
-				};
-				Matrix<int> B = new int[,]
-				{
-					{ 1, 2, 3, },
-					{ 4, 5, 6, },
-					{ 7, 8, 9, },
-				};
-				Assert.IsTrue(A / 2 == B);
-			}
-
-			// float
-			{
-				Matrix<float> A = new float[,]
-				{
-					{  2f,  4f,  6f, },
-					{  8f, 10f, 12f, },
-					{ 14f, 16f, 18f, },
-				};
-				Matrix<float> B = new float[,]
-				{
-					{ 1f, 2f, 3f, },
-					{ 4f, 5f, 6f, },
-					{ 7f, 8f, 9f, },
-				};
-				Assert.IsTrue(A / 2f == B);
-			}
-
-			// double
-			{
-				Matrix<double> A = new double[,]
-				{
-					{  2d,  4d,  6d, },
-					{  8d, 10d, 12d, },
-					{ 14d, 16d, 18d, },
-				};
-				Matrix<double> B = new double[,]
-				{
-					{ 1d, 2d, 3d, },
-					{ 4d, 5d, 6d, },
-					{ 7d, 8d, 9d, },
-				};
-				Assert.IsTrue(A / 2d == B);
-			}
-
-			// decimal
-			{
-				Matrix<decimal> A = new decimal[,]
-				{
-					{  2m,  4m,  6m, },
-					{  8m, 10m, 12m, },
-					{ 14m, 16m, 18m, },
-				};
-				Matrix<decimal> B = new decimal[,]
-				{
-					{ 1m, 2m, 3m, },
-					{ 4m, 5m, 6m, },
-					{ 7m, 8m, 9m, },
-				};
-				Assert.IsTrue(A / 2m == B);
-			}
-		}
-
-		#endregion
-
-		#region Power
-
-		[TestMethod] public void Power()
-		{
-			// int
-			{
-				Matrix<int> A = new int[,]
-				{
-					{ 1, 2, },
-					{ 3, 4, },
-				};
-				Matrix<int> B = new int[,]
-				{
-					{ 37,  54, },
-					{ 81, 118, },
-				};
-				Assert.IsTrue((A ^ 3) == B);
-			}
-
-			// float
-			{
-				Matrix<float> A = new float[,]
-				{
-					{ 1f, 2f, },
-					{ 3f, 4f, },
-				};
-				Matrix<float> B = new float[,]
-				{
-					{ 37f,  54f, },
-					{ 81f, 118f, },
-				};
-				Assert.IsTrue((A ^ 3) == B);
-			}
-
-			// double
-			{
-				Matrix<double> A = new double[,]
-				{
-					{ 1d, 2d, },
-					{ 3d, 4d, },
-				};
-				Matrix<double> B = new double[,]
-				{
-					{ 37d,  54d, },
-					{ 81d, 118d, },
-				};
-				Assert.IsTrue((A ^ 3) == B);
-			}
-
-			// decimal
-			{
-				Matrix<decimal> A = new decimal[,]
-				{
-					{ 1m, 2m, },
-					{ 3m, 4m, },
-				};
-				Matrix<decimal> B = new decimal[,]
-				{
-					{ 37m,  54m, },
-					{ 81m, 118m, },
-				};
-				Assert.IsTrue((A ^ 3) == B);
-			}
-
-			// Exceptions
-			{
-				Matrix<decimal> A = new Matrix<decimal>(2, 3);
-				Assert.ThrowsException<MathematicsException>(() => A ^ 3);
-			}
-		}
-
-		#endregion
-
-		#region Determinent
-
-		[TestMethod] public void Determinent()
-		{
-			// int 
-			{
-				Matrix<int> a = new int[,]
-				{
-					{ 1, 2, },
-					{ 3, 4, },
-				};
-				Assert.IsTrue(a.Determinent() == -2);
-			}
-			{
-				Matrix<int> a = new int[,]
-				{
-					{ 1, 2, 3, },
-					{ 4, 5, 6, },
-					{ 7, 8, 9, },
-				};
-				Assert.IsTrue(a.Determinent() == 0);
-			}
-
-			// float
-			{
-				Matrix<float> a = new float[,]
-				{
-					{ 1f, 2f, },
-					{ 3f, 4f, },
-				};
-				Assert.IsTrue(a.Determinent() == -2);
-			}
-			{
-				Matrix<float> a = new float[,]
-				{
-					{ 1f, 2f, 3f, },
-					{ 4f, 5f, 6f, },
-					{ 7f, 8f, 9f, },
-				};
-				Assert.IsTrue(a.Determinent() == 0);
-			}
-
-			// double
-			{
-				Matrix<double> a = new double[,]
-				{
-					{ 1d, 2d, },
-					{ 3d, 4d, },
-				};
-				Assert.IsTrue(a.Determinent() == -2);
-			}
-			{
-				Matrix<double> a = new double[,]
-				{
-					{ 1d, 2d, 3d, },
-					{ 4d, 5d, 6d, },
-					{ 7d, 8d, 9d, },
-				};
-				Assert.IsTrue(a.Determinent() == 0);
-			}
-
-			// decimal
-			{
-				Matrix<decimal> a = new decimal[,]
-				{
-					{ 1m, 2m, },
-					{ 3m, 4m, },
-				};
-				Assert.IsTrue(a.Determinent() == -2);
-			}
-			{
-				Matrix<decimal> a = new decimal[,]
-				{
-					{ 1m, 2m, 3m, },
-					{ 4m, 5m, 6m, },
-					{ 7m, 8m, 9m, },
-				};
-				Assert.IsTrue(a.Determinent() == 0);
-			}
-
-			// Exceptions
-			{
-				Matrix<decimal> a = new Matrix<decimal>(2, 3);
-				Assert.ThrowsException<MathematicsException>(() => a.Determinent());
-			}
-		}
-
-		#endregion
+        #endregion
 
 		#region Trace
 


### PR DESCRIPTION
With help of https://codereview.stackexchange.com/questions/204135/determinant-using-gauss-elimination

Big inner class MatrixElementFraction<T> is necessary because some types like int lose precision when being divided, so that 3 / 2 + 1 / 2 = 1 instead of 2. We compensate it with saying that 3 / 2 + 1 / 2 = (3 + 1) / 2 = 2.