### PR TITLE
Non-numerical Gaussian elimination

### DIFF
--- a/Sources/Towel/Constant.cs
+++ b/Sources/Towel/Constant.cs
@@ -92,8 +92,8 @@ namespace Towel
 			// this is necessary because user's classes may not contain <, >, etc. operators, but they shouldn't be required
 			// to define them to work with, say, matrices
 			if (!(typeof(T).GetMethod("op_GreaterThanOrEqual", BindingFlags.Static | BindingFlags.Public) is null) || typeof(T) == typeof(int))
-			    pi = Maximum(pi, Constant<T>.Three);
-            return pi;
+				pi = Maximum(pi, Constant<T>.Three);
+			return pi;
 		}
 
 		internal static class AddMultiplyDivideAddImplementation

--- a/Sources/Towel/Constant.cs
+++ b/Sources/Towel/Constant.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
+using System.Reflection;
 using static Towel.Syntax;
 
 namespace Towel
@@ -87,8 +88,12 @@ namespace Towel
 				}
 				pi = Multiplication(Constant<T>.Two, pi);
 			}
-			pi = Maximum(pi, Constant<T>.Three);
-			return pi;
+			
+			// this is necessary because user's classes may not contain <, >, etc. operators, but they shouldn't be required
+			// to define them to work with, say, matrices
+			if (!(typeof(T).GetMethod("op_GreaterThanOrEqual", BindingFlags.Static | BindingFlags.Public) is null) || typeof(T) == typeof(int))
+			    pi = Maximum(pi, Constant<T>.Three);
+            return pi;
 		}
 
 		internal static class AddMultiplyDivideAddImplementation

--- a/Sources/Towel/Mathematics/Matrix.cs
+++ b/Sources/Towel/Mathematics/Matrix.cs
@@ -461,10 +461,7 @@ namespace Towel.Mathematics
 				=> new MatrixElementFraction<T>(AbsoluteValue(Numerator), AbsoluteValue(Denominator));
 
 			public bool IsDividedByZero => Compare.Default(Denominator, Constant<T>.Zero) == CompareResult.Equal;
-
-            public override string ToString()
-                => $"{Numerator.ToString()} / {Denominator.ToString()}";
-        }
+		}
 #endregion
 
 #region GetDeterminant Gaussian elimination analytically
@@ -1380,10 +1377,10 @@ namespace Towel.Mathematics
 
         /// <summary>Computes the determinant of a square matrix via Gaussian elimination.</summary>
         /// <returns>The computed determinant.</returns>
-        public T DeterminantNonNumericGaussian()
-        {
-            return DeterminantNonNumericGaussian(this);
-        }
+		public T DeterminantNonNumericGaussian()
+		{
+			return DeterminantNonNumericGaussian(this);
+		}
 
 		#endregion
 

--- a/Sources/Towel/Mathematics/Matrix.cs
+++ b/Sources/Towel/Mathematics/Matrix.cs
@@ -384,7 +384,7 @@ namespace Towel.Mathematics
 
 		#endregion
 
-        // Used for determinants
+		// Used for determinants
 		#region MatrixElementFraction
 		/// <summary>
 		/// Used to avoid issues when 1/2 + 1/2 = 0 + 0 = 0 instead of 1 for types, where division results in precision loss
@@ -468,27 +468,27 @@ namespace Towel.Mathematics
 #endregion
 
 #region GetDeterminant Gaussian elimination analytically
-        internal static T GetDeterminantNonNumericGaussian(Matrix<T> matrix, int n)
-        {
-            if (n == 1)
-                return matrix.Get(0, 0);
+		internal static T GetDeterminantNonNumericGaussian(Matrix<T> matrix, int n)
+		{
+			if (n == 1)
+				return matrix.Get(0, 0);
 
-            var elemMatrix = new Matrix<MatrixElementFraction<T>>(n, n, 
-                (x, y) => new MatrixElementFraction<T>(matrix.Get(x, y)));
-            for (int k = 1; k < n; k++)
-                for (int j = k; j < n; j++)
-                {
-                    var m = elemMatrix.Get(j, k - 1) / elemMatrix.Get(k - 1, k - 1);
-                    for (int i = 0; i < n + 0; i++)
-                        elemMatrix.Set(j, i, elemMatrix.Get(j, i) - m * elemMatrix.Get(k - 1, i));
-                }
+			var elemMatrix = new Matrix<MatrixElementFraction<T>>(n, n, 
+				(x, y) => new MatrixElementFraction<T>(matrix.Get(x, y)));
+			for (int k = 1; k < n; k++)
+				for (int j = k; j < n; j++)
+				{
+					var m = elemMatrix.Get(j, k - 1) / elemMatrix.Get(k - 1, k - 1);
+					for (int i = 0; i < n + 0; i++)
+						elemMatrix.Set(j, i, elemMatrix.Get(j, i) - m * elemMatrix.Get(k - 1, i));
+				}
 
-            var det = new MatrixElementFraction<T>(Constant<T>.One);
-            for (int i = 0; i < n; i++)
-                det *= elemMatrix.Get(i, i);
+			var det = new MatrixElementFraction<T>(Constant<T>.One);
+			for (int i = 0; i < n; i++)
+				det *= elemMatrix.Get(i, i);
 
-            return det.Value;
-        }
+			return det.Value;
+		}
 		#endregion
 
 		#region GetDeterminant Gaussian elimination
@@ -1327,21 +1327,21 @@ namespace Towel.Mathematics
 			return GetDeterminantGaussian(a, a.Rows);
 		}
 
-        /// <summary>Computes the determinant of a square matrix via Gaussian elimination
-        /// for elements which don't have less, greater operators implemented
-        /// </summary>
-        /// <param name="a">The matrix to compute the determinant of.</param>
-        /// <returns>The computed determinant.</returns>
-        /// <runtime>O((n^3 + 2n^−3) / 3)</runtime>
-        public static T DeterminantNonNumericGaussian(Matrix<T> a)
-        {
-            _ = a ?? throw new ArgumentNullException(nameof(a));
-            if (!a.IsSquare)
-            {
-                throw new MathematicsException("Argument invalid !(" + nameof(a) + "." + nameof(a.IsSquare) + ")");
-            }
-            return GetDeterminantNonNumericGaussian(a, a.Rows);
-        }
+		/// <summary>Computes the determinant of a square matrix via Gaussian elimination
+		/// for elements which don't have less, greater operators implemented
+		/// </summary>
+		/// <param name="a">The matrix to compute the determinant of.</param>
+		/// <returns>The computed determinant.</returns>
+		/// <runtime>O((n^3 + 2n^−3) / 3)</runtime>
+		public static T DeterminantNonNumericGaussian(Matrix<T> a)
+		{
+			_ = a ?? throw new ArgumentNullException(nameof(a));
+			if (!a.IsSquare)
+			{
+				throw new MathematicsException("Argument invalid !(" + nameof(a) + "." + nameof(a.IsSquare) + ")");
+			}
+			return GetDeterminantNonNumericGaussian(a, a.Rows);
+		}
 
 		/// <summary>Computes the determinant of a square matrix via Laplace's method.</summary>
 		/// <param name="a">The matrix to compute the determinant of.</param>

--- a/Sources/Towel/Towel.xml
+++ b/Sources/Towel/Towel.xml
@@ -16885,6 +16885,14 @@
             <returns>The computed determinant.</returns>
             <runtime>O((n^3 + 2n^−3) / 3)</runtime>
         </member>
+        <member name="M:Towel.Mathematics.Matrix`1.DeterminantNonNumericGaussian(Towel.Mathematics.Matrix{`0})">
+            <summary>Computes the determinant of a square matrix via Gaussian elimination
+            for elements which don't have less, greater operators implemented
+            </summary>
+            <param name="a">The matrix to compute the determinant of.</param>
+            <returns>The computed determinant.</returns>
+            <runtime>O((n^3 + 2n^−3) / 3)</runtime>
+        </member>
         <member name="M:Towel.Mathematics.Matrix`1.DeterminantLaplace(Towel.Mathematics.Matrix{`0})">
             <summary>Computes the determinant of a square matrix via Laplace's method.</summary>
             <param name="a">The matrix to compute the determinant of.</param>
@@ -16900,6 +16908,10 @@
             <returns>The computed determinant.</returns>
         </member>
         <member name="M:Towel.Mathematics.Matrix`1.DeterminantGaussian">
+            <summary>Computes the determinant of a square matrix via Gaussian elimination.</summary>
+            <returns>The computed determinant.</returns>
+        </member>
+        <member name="M:Towel.Mathematics.Matrix`1.DeterminantNonNumericGaussian">
             <summary>Computes the determinant of a square matrix via Gaussian elimination.</summary>
             <returns>The computed determinant.</returns>
         </member>


### PR DESCRIPTION
After implementing Gaussian elimination I actually discovered that it's not what I needed myself. Your type might not support >, <, >=, <= operators, thus, you need an analytical presentation of determinant. For example, I'm thinking of using Matrix for my symbolic algebra, but since we can't compare expressions, I needed that:
```cs
var a = new Matrix<Entity>(2, 2);
a[0, 0] = "x + 2";
a[1, 0] = "y";
a[0, 1] = "2 ^ x";
a[1, 1] = "z";
Console.WriteLine(a.DeterminantNonNumericGaussian().Simplify());
```

So I implemented it. Output for the example above:
```
(x + 2) * z - 2 ^ x * y
```

However, I think it requires some work. First, #55: I added a reflection check for that operator, but @ZacharyPatten you should probably rewrite it to meet your own views on this.

Not only that, you could actually consider replacing Gaussian with NonNumericalGaussian, I just don't know how to test it better.