### PR TITLE
Multiple replacing for strings

### DIFF
--- a/Sources/Towel/Extensions.cs
+++ b/Sources/Towel/Extensions.cs
@@ -48,7 +48,7 @@ namespace Towel
 				throw new InvalidOperationException("Attempting a contains check with an empty set.");
 			}
 
-            ISet<char> set = new SetHashLinked<char>();
+			ISet<char> set = new SetHashLinked<char>();
 			foreach (char c in chars)
 			{
 				set.Add(c);

--- a/Sources/Towel/Extensions.cs
+++ b/Sources/Towel/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
@@ -24,6 +25,17 @@ namespace Towel
 			return @string;
 		}
 
+		/// <summary>Applies all replacement rules to a string</summary>
+		/// <param name="string">The string to sequentially apply the replacement rules</param>
+		/// <param name="rules">An IEnumerable of pairs of rules</param>
+		/// <returns>New string with those replacement rules applied</returns>
+		public static string Replace(this string @string, IEnumerable<(string oldPattern, string newPattern)> rules)
+		{
+			foreach (var rule in rules)
+				@string = @string.Replace(rule.oldPattern, rule.newPattern);
+			return @string;
+		}
+
 		/// <summary>Checks if a string contains any of a collections on characters.</summary>
 		/// <param name="string">The string to see if it contains any of the specified characters.</param>
 		/// <param name="chars">The characters to check if the string contains any of them.</param>
@@ -37,7 +49,7 @@ namespace Towel
 				throw new InvalidOperationException("Attempting a contains check with an empty set.");
 			}
 
-			ISet<char> set = new SetHashLinked<char>();
+            DataStructures.ISet<char> set = new SetHashLinked<char>();
 			foreach (char c in chars)
 			{
 				set.Add(c);

--- a/Sources/Towel/Extensions.cs
+++ b/Sources/Towel/Extensions.cs
@@ -33,7 +33,6 @@ namespace Towel
 		private static bool StringMatchesLinkList(ListLinked<char>.Node since, ref string toMatch, out ListLinked<char>.Node firstNotToMatch)
 		{
 			var id = 0;
-			ListLinked<char>.Node last = null;
 			while (since is {} && id < toMatch.Length)
 			{
 				if (since.Value != toMatch[id])
@@ -42,13 +41,18 @@ namespace Towel
 					return false;
 				}
 				id++;
-				last = since;
 				since = since.Next;
 			}
 			firstNotToMatch = since;
 			return true;
 		}
 
+		/// <summary>
+		///   f g h
+		/// a b \/ c d
+		/// =>
+		/// a b f g h c d
+		/// </summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private static void ReplaceInLinkedList(ListLinked<char> dstAndSrc, ref string oldPattern, ref string newPattern)
 		{
@@ -61,6 +65,8 @@ namespace Towel
 					curr = firstNotToMatch;
 					for (int cid = 0; cid < newPattern.Length; cid++)
 					{
+						// TODO: actually, we could use already created nodes instead
+						// of creating new ones. Also, we surely need a factory for that
 						if (cid == 0)
 							prev.Value = newPattern[cid];
 						else

--- a/Sources/Towel/Extensions.cs
+++ b/Sources/Towel/Extensions.cs
@@ -13,6 +13,17 @@ namespace Towel
 	{
 		#region System.String
 
+        /// <summary>Applies all replacement rules to a string</summary>
+        /// <param name="string">The string to sequentially apply the replacement rules</param>
+        /// <param name="rules">The array of pair of strings where the first one is replaced by the second one</param>
+        /// <returns>New string with those replacement rules applied</returns>
+        public static string Replace(this string @string, params (string oldPattern, string newPattern)[] rules)
+        {
+            foreach (var rule in rules)
+                @string = @string.Replace(rule.oldPattern, rule.newPattern);
+            return @string;
+        }
+
 		/// <summary>Checks if a string contains any of a collections on characters.</summary>
 		/// <param name="string">The string to see if it contains any of the specified characters.</param>
 		/// <param name="chars">The characters to check if the string contains any of them.</param>

--- a/Sources/Towel/Extensions.cs
+++ b/Sources/Towel/Extensions.cs
@@ -13,16 +13,16 @@ namespace Towel
 	{
 		#region System.String
 
-        /// <summary>Applies all replacement rules to a string</summary>
-        /// <param name="string">The string to sequentially apply the replacement rules</param>
-        /// <param name="rules">The array of pair of strings where the first one is replaced by the second one</param>
-        /// <returns>New string with those replacement rules applied</returns>
-        public static string Replace(this string @string, params (string oldPattern, string newPattern)[] rules)
-        {
-            foreach (var rule in rules)
-                @string = @string.Replace(rule.oldPattern, rule.newPattern);
-            return @string;
-        }
+		/// <summary>Applies all replacement rules to a string</summary>
+		/// <param name="string">The string to sequentially apply the replacement rules</param>
+		/// <param name="rules">The array of pair of strings where the first one is replaced by the second one</param>
+		/// <returns>New string with those replacement rules applied</returns>
+		public static string Replace(this string @string, params (string oldPattern, string newPattern)[] rules)
+		{
+			foreach (var rule in rules)
+				@string = @string.Replace(rule.oldPattern, rule.newPattern);
+			return @string;
+		}
 
 		/// <summary>Checks if a string contains any of a collections on characters.</summary>
 		/// <param name="string">The string to see if it contains any of the specified characters.</param>

--- a/Sources/Towel/Extensions.cs
+++ b/Sources/Towel/Extensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
@@ -29,7 +28,7 @@ namespace Towel
 		/// <param name="string">The string to sequentially apply the replacement rules</param>
 		/// <param name="rules">An IEnumerable of pairs of rules</param>
 		/// <returns>New string with those replacement rules applied</returns>
-		public static string Replace(this string @string, IEnumerable<(string oldPattern, string newPattern)> rules)
+		public static string Replace(this string @string, System.Collections.Generic.IEnumerable<(string oldPattern, string newPattern)> rules)
 		{
 			foreach (var rule in rules)
 				@string = @string.Replace(rule.oldPattern, rule.newPattern);

--- a/Sources/Towel/Extensions.cs
+++ b/Sources/Towel/Extensions.cs
@@ -48,7 +48,7 @@ namespace Towel
 				throw new InvalidOperationException("Attempting a contains check with an empty set.");
 			}
 
-            DataStructures.ISet<char> set = new SetHashLinked<char>();
+            ISet<char> set = new SetHashLinked<char>();
 			foreach (char c in chars)
 			{
 				set.Add(c);

--- a/Sources/Towel/Towel.xml
+++ b/Sources/Towel/Towel.xml
@@ -15235,6 +15235,12 @@
         <member name="T:Towel.Extensions">
             <summary>Contains Extension methods on common System types.</summary>
         </member>
+        <member name="M:Towel.Extensions.Replace(System.String,System.ValueTuple{System.String,System.String}[])">
+            <summary>Applies all replacement rules to a string</summary>
+            <param name="string">The string to sequentially apply the replacement rules</param>
+            <param name="rules">The array of pair of strings where the first one is replaced by the second one</param>
+            <returns>New string with those replacement rules applied</returns>
+        </member>
         <member name="M:Towel.Extensions.ContainsAny(System.String,System.Char[])">
             <summary>Checks if a string contains any of a collections on characters.</summary>
             <param name="string">The string to see if it contains any of the specified characters.</param>

--- a/Sources/Towel/Towel.xml
+++ b/Sources/Towel/Towel.xml
@@ -15241,6 +15241,12 @@
             <param name="rules">The array of pair of strings where the first one is replaced by the second one</param>
             <returns>New string with those replacement rules applied</returns>
         </member>
+        <member name="M:Towel.Extensions.Replace(System.String,System.Collections.Generic.IEnumerable{System.ValueTuple{System.String,System.String}})">
+            <summary>Applies all replacement rules to a string</summary>
+            <param name="string">The string to sequentially apply the replacement rules</param>
+            <param name="rules">An IEnumerable of pairs of rules</param>
+            <returns>New string with those replacement rules applied</returns>
+        </member>
         <member name="M:Towel.Extensions.ContainsAny(System.String,System.Char[])">
             <summary>Checks if a string contains any of a collections on characters.</summary>
             <param name="string">The string to see if it contains any of the specified characters.</param>

--- a/Tools/Towel_Testing/Extensions.cs
+++ b/Tools/Towel_Testing/Extensions.cs
@@ -9,28 +9,37 @@ namespace Towel_Testing
 	{
 		#region Decimal Testing
 
+        [TestMethod] public void String_MultipleReplacing()
+        {
+            Assert.AreEqual("run go swim".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "ran went swam");
+            Assert.AreEqual("quack".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "quack");
+        }
+
+        public void AssertAreEqualReversed<A, B>(A actual, B expected)
+            => Assert.AreEqual(expected, actual);
+
 		[TestMethod] public void Decimal_ToEnglishWords()
 		{
-			Assert.IsTrue((        0m).ToEnglishWords() == "Zero");
-			Assert.IsTrue((        1m).ToEnglishWords() == "One");
-			Assert.IsTrue((       -1m).ToEnglishWords() == "Negative One");
-			Assert.IsTrue((        2m).ToEnglishWords() == "Two");
-			Assert.IsTrue((       -2m).ToEnglishWords() == "Negative Two");
-			Assert.IsTrue((      1.5m).ToEnglishWords() == "One And Five Tenths");
-			Assert.IsTrue((       69m).ToEnglishWords() == "Sixty-Nine");
-			Assert.IsTrue((      120m).ToEnglishWords() == "One Hundred Twenty");
-			Assert.IsTrue((     1300m).ToEnglishWords() == "One Thousand Three Hundred");
-			Assert.IsTrue((     7725m).ToEnglishWords() == "Seven Thousand Seven Hundred Twenty-Five");
-			Assert.IsTrue((       12m).ToEnglishWords() == "Twelve");
-			Assert.IsTrue((     1000m).ToEnglishWords() == "One Thousand");
-			Assert.IsTrue((    10000m).ToEnglishWords() == "Ten Thousand");
-			Assert.IsTrue((   100000m).ToEnglishWords() == "One Hundred Thousand");
-			Assert.IsTrue((  1000000m).ToEnglishWords() == "One Million");
-			Assert.IsTrue(( 10000000m).ToEnglishWords() == "Ten Million");
-			Assert.IsTrue((100000000m).ToEnglishWords() == "One Hundred Million");
-			Assert.IsTrue((   0.1234m).ToEnglishWords() == "One Thousand Two Hundred Thirty-Four Ten-Thousandths");
-			Assert.IsTrue((  -0.1234m).ToEnglishWords() == "Negative One Thousand Two Hundred Thirty-Four Ten-Thousandths");
-			Assert.IsTrue(decimal.MaxValue.ToEnglishWords() == "Seventy-Nine Octillion Two Hundred Twenty-Eight Septillion One Hundred Sixty-Two Sextillion Five Hundred Fourteen Quintillion Two Hundred Sixty-Four Quadrillion Three Hundred Thirty-Seven Trillion Five Hundred Ninety-Three Billion Five Hundred Forty-Three Million Nine Hundred Fifty Thousand Three Hundred Thirty-Five");
+            AssertAreEqualReversed((        0m).ToEnglishWords(), "Zero");
+            AssertAreEqualReversed((        1m).ToEnglishWords(), "One");
+            AssertAreEqualReversed((       -1m).ToEnglishWords(), "Negative One");
+            AssertAreEqualReversed((        2m).ToEnglishWords(), "Two");
+            AssertAreEqualReversed((       -2m).ToEnglishWords(), "Negative Two");
+            AssertAreEqualReversed((      1.5m).ToEnglishWords(), "One And Five Tenths");
+            AssertAreEqualReversed((       69m).ToEnglishWords(), "Sixty-Nine");
+            AssertAreEqualReversed((      120m).ToEnglishWords(), "One Hundred Twenty");
+            AssertAreEqualReversed((     1300m).ToEnglishWords(), "One Thousand Three Hundred");
+            AssertAreEqualReversed((     7725m).ToEnglishWords(), "Seven Thousand Seven Hundred Twenty-Five");
+            AssertAreEqualReversed((       12m).ToEnglishWords(), "Twelve");
+            AssertAreEqualReversed((     1000m).ToEnglishWords(), "One Thousand");
+            AssertAreEqualReversed((    10000m).ToEnglishWords(), "Ten Thousand");
+            AssertAreEqualReversed((   100000m).ToEnglishWords(), "One Hundred Thousand");
+            AssertAreEqualReversed((  1000000m).ToEnglishWords(), "One Million");
+            AssertAreEqualReversed(( 10000000m).ToEnglishWords(), "Ten Million");
+            AssertAreEqualReversed((100000000m).ToEnglishWords(), "One Hundred Million");
+            AssertAreEqualReversed((   0.1234m).ToEnglishWords(), "One Thousand Two Hundred Thirty-Four Ten-Thousandths");
+            AssertAreEqualReversed((  -0.1234m).ToEnglishWords(), "Negative One Thousand Two Hundred Thirty-Four Ten-Thousandths");
+            AssertAreEqualReversed(decimal.MaxValue.ToEnglishWords(), "Seventy-Nine Octillion Two Hundred Twenty-Eight Septillion One Hundred Sixty-Two Sextillion Five Hundred Fourteen Quintillion Two Hundred Sixty-Four Quadrillion Three Hundred Thirty-Seven Trillion Five Hundred Ninety-Three Billion Five Hundred Forty-Three Million Nine Hundred Fifty Thousand Three Hundred Thirty-Five");
 
 			// test a bunch of whole numbers for exceptions
 			for (decimal i = 0; i < 1000000; i += 13)

--- a/Tools/Towel_Testing/Extensions.cs
+++ b/Tools/Towel_Testing/Extensions.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections;
 using Towel;
 using Towel.DataStructures;
 

--- a/Tools/Towel_Testing/Extensions.cs
+++ b/Tools/Towel_Testing/Extensions.cs
@@ -11,11 +11,14 @@ namespace Towel_Testing
 
 		[TestMethod] public void String_MultipleReplacing()
 		{
-			Assert.AreEqual("run go swim".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "ran went swam");
-			Assert.AreEqual("quack".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "quack");
+			AssertAreEqualReversed("towel".Replace(("wel", "rtoise")), "tortoise");
+			AssertAreEqualReversed("run go swim".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "ran went swam");
+			AssertAreEqualReversed("quack".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "quack");
+			AssertAreEqualReversed("quack".Replace(("q", "k")), "kuack");
+			AssertAreEqualReversed("quack".Replace(("qu", "12"), ("ck", "666")), "12a666");
 
 			System.Collections.Generic.IEnumerable<(string, string)> someIEnum = new[] {("run", "ran"), ("swim", "swam"), ("go", "went")};
-			Assert.AreEqual("run go swim".Replace(someIEnum), "ran went swam");
+			AssertAreEqualReversed("run go swim".Replace(someIEnum), "ran went swam");
 		}
 
 		public void AssertAreEqualReversed<A, B>(A actual, B expected)

--- a/Tools/Towel_Testing/Extensions.cs
+++ b/Tools/Towel_Testing/Extensions.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using Towel;
 using Towel.DataStructures;
 
@@ -16,7 +15,7 @@ namespace Towel_Testing
 			Assert.AreEqual("run go swim".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "ran went swam");
 			Assert.AreEqual("quack".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "quack");
 
-			IEnumerable<(string, string)> someIEnum = new[] {("run", "ran"), ("swim", "swam"), ("go", "went")};
+			System.Collections.Generic.IEnumerable<(string, string)> someIEnum = new[] {("run", "ran"), ("swim", "swam"), ("go", "went")};
 			Assert.AreEqual("run go swim".Replace(someIEnum), "ran went swam");
 		}
 
@@ -85,19 +84,19 @@ namespace Towel_Testing
 			{ // test shifting from maxValue
 				int i = 999;
 				TestingRandom random = new TestingRandom(() => i--);
-                Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
+				ISet<int> set = new SetHashLinked<int>();
 				random.NextUnique(5, 0, 1000, j => { Assert.IsFalse(set.Contains(j)); set.Add(j); });
 				Assert.IsTrue(set.Count == 5);
 			}
 			{ // test shifting from 0
 				TestingRandom random = new TestingRandom(() => 0);
-                Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
+				ISet<int> set = new SetHashLinked<int>();
 				random.NextUnique(5, 0, 1000, i => { Assert.IsFalse(set.Contains(i)); set.Add(i); });
 				Assert.IsTrue(set.Count == 5);
 			}
 			{ // test shifting from inner value
 				TestingRandom random = new TestingRandom(() => 7);
-                Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
+				ISet<int> set = new SetHashLinked<int>();
 				random.NextUnique(5, 0, 1000, i => { Assert.IsFalse(set.Contains(i)); set.Add(i); });
 				Assert.IsTrue(set.Count == 5);
 			}
@@ -105,7 +104,7 @@ namespace Towel_Testing
 				Random random = new Random();
 				for (int i = 0; i < 10000; i++)
 				{
-                    Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
+					ISet<int> set = new SetHashLinked<int>();
 					random.NextUnique(5, 0, 1000, j => { Assert.IsFalse(set.Contains(j)); set.Add(j); });
 					Assert.IsTrue(set.Count == 5);
 				}
@@ -126,19 +125,19 @@ namespace Towel_Testing
 			{ // test shifting from maxValue
 				int i = 999;
 				TestingRandom random = new TestingRandom(() => i--);
-                Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
+				ISet<int> set = new SetHashLinked<int>();
 				random.NextUnique(100, 0, 1000, j => { Assert.IsFalse(set.Contains(j)); set.Add(j); });
 				Assert.IsTrue(set.Count == 100);
 			}
 			{ // test shifting from 0
 				TestingRandom random = new TestingRandom(() => 0);
-                Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
+				ISet<int> set = new SetHashLinked<int>();
 				random.NextUnique(100, 0, 1000, i => { Assert.IsFalse(set.Contains(i)); set.Add(i); });
 				Assert.IsTrue(set.Count == 100);
 			}
 			{ // test shifting from inner value
 				TestingRandom random = new TestingRandom(() => 7);
-                Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
+				ISet<int> set = new SetHashLinked<int>();
 				random.NextUnique(100, 0, 1000, i => { Assert.IsFalse(set.Contains(i)); set.Add(i); });
 				Assert.IsTrue(set.Count == 100);
 			}
@@ -146,7 +145,7 @@ namespace Towel_Testing
 				Random random = new Random();
 				for (int i = 0; i < 10000; i++)
 				{
-                    Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
+					ISet<int> set = new SetHashLinked<int>();
 					random.NextUnique(100, 0, 1000, j => { Assert.IsFalse(set.Contains(j)); set.Add(j); });
 					Assert.IsTrue(set.Count == 100);
 				}

--- a/Tools/Towel_Testing/Extensions.cs
+++ b/Tools/Towel_Testing/Extensions.cs
@@ -9,37 +9,37 @@ namespace Towel_Testing
 	{
 		#region Decimal Testing
 
-        [TestMethod] public void String_MultipleReplacing()
-        {
-            Assert.AreEqual("run go swim".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "ran went swam");
-            Assert.AreEqual("quack".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "quack");
-        }
+		[TestMethod] public void String_MultipleReplacing()
+		{
+			Assert.AreEqual("run go swim".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "ran went swam");
+			Assert.AreEqual("quack".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "quack");
+		}
 
-        public void AssertAreEqualReversed<A, B>(A actual, B expected)
-            => Assert.AreEqual(expected, actual);
+		public void AssertAreEqualReversed<A, B>(A actual, B expected)
+			=> Assert.AreEqual(expected, actual);
 
 		[TestMethod] public void Decimal_ToEnglishWords()
 		{
-            AssertAreEqualReversed((        0m).ToEnglishWords(), "Zero");
-            AssertAreEqualReversed((        1m).ToEnglishWords(), "One");
-            AssertAreEqualReversed((       -1m).ToEnglishWords(), "Negative One");
-            AssertAreEqualReversed((        2m).ToEnglishWords(), "Two");
-            AssertAreEqualReversed((       -2m).ToEnglishWords(), "Negative Two");
-            AssertAreEqualReversed((      1.5m).ToEnglishWords(), "One And Five Tenths");
-            AssertAreEqualReversed((       69m).ToEnglishWords(), "Sixty-Nine");
-            AssertAreEqualReversed((      120m).ToEnglishWords(), "One Hundred Twenty");
-            AssertAreEqualReversed((     1300m).ToEnglishWords(), "One Thousand Three Hundred");
-            AssertAreEqualReversed((     7725m).ToEnglishWords(), "Seven Thousand Seven Hundred Twenty-Five");
-            AssertAreEqualReversed((       12m).ToEnglishWords(), "Twelve");
-            AssertAreEqualReversed((     1000m).ToEnglishWords(), "One Thousand");
-            AssertAreEqualReversed((    10000m).ToEnglishWords(), "Ten Thousand");
-            AssertAreEqualReversed((   100000m).ToEnglishWords(), "One Hundred Thousand");
-            AssertAreEqualReversed((  1000000m).ToEnglishWords(), "One Million");
-            AssertAreEqualReversed(( 10000000m).ToEnglishWords(), "Ten Million");
-            AssertAreEqualReversed((100000000m).ToEnglishWords(), "One Hundred Million");
-            AssertAreEqualReversed((   0.1234m).ToEnglishWords(), "One Thousand Two Hundred Thirty-Four Ten-Thousandths");
-            AssertAreEqualReversed((  -0.1234m).ToEnglishWords(), "Negative One Thousand Two Hundred Thirty-Four Ten-Thousandths");
-            AssertAreEqualReversed(decimal.MaxValue.ToEnglishWords(), "Seventy-Nine Octillion Two Hundred Twenty-Eight Septillion One Hundred Sixty-Two Sextillion Five Hundred Fourteen Quintillion Two Hundred Sixty-Four Quadrillion Three Hundred Thirty-Seven Trillion Five Hundred Ninety-Three Billion Five Hundred Forty-Three Million Nine Hundred Fifty Thousand Three Hundred Thirty-Five");
+			AssertAreEqualReversed((        0m).ToEnglishWords(), "Zero");
+			AssertAreEqualReversed((        1m).ToEnglishWords(), "One");
+			AssertAreEqualReversed((       -1m).ToEnglishWords(), "Negative One");
+			AssertAreEqualReversed((        2m).ToEnglishWords(), "Two");
+			AssertAreEqualReversed((       -2m).ToEnglishWords(), "Negative Two");
+			AssertAreEqualReversed((      1.5m).ToEnglishWords(), "One And Five Tenths");
+			AssertAreEqualReversed((       69m).ToEnglishWords(), "Sixty-Nine");
+			AssertAreEqualReversed((      120m).ToEnglishWords(), "One Hundred Twenty");
+			AssertAreEqualReversed((     1300m).ToEnglishWords(), "One Thousand Three Hundred");
+			AssertAreEqualReversed((     7725m).ToEnglishWords(), "Seven Thousand Seven Hundred Twenty-Five");
+			AssertAreEqualReversed((       12m).ToEnglishWords(), "Twelve");
+			AssertAreEqualReversed((     1000m).ToEnglishWords(), "One Thousand");
+			AssertAreEqualReversed((    10000m).ToEnglishWords(), "Ten Thousand");
+			AssertAreEqualReversed((   100000m).ToEnglishWords(), "One Hundred Thousand");
+			AssertAreEqualReversed((  1000000m).ToEnglishWords(), "One Million");
+			AssertAreEqualReversed(( 10000000m).ToEnglishWords(), "Ten Million");
+			AssertAreEqualReversed((100000000m).ToEnglishWords(), "One Hundred Million");
+			AssertAreEqualReversed((   0.1234m).ToEnglishWords(), "One Thousand Two Hundred Thirty-Four Ten-Thousandths");
+			AssertAreEqualReversed((  -0.1234m).ToEnglishWords(), "Negative One Thousand Two Hundred Thirty-Four Ten-Thousandths");
+			AssertAreEqualReversed(decimal.MaxValue.ToEnglishWords(), "Seventy-Nine Octillion Two Hundred Twenty-Eight Septillion One Hundred Sixty-Two Sextillion Five Hundred Fourteen Quintillion Two Hundred Sixty-Four Quadrillion Three Hundred Thirty-Seven Trillion Five Hundred Ninety-Three Billion Five Hundred Forty-Three Million Nine Hundred Fifty Thousand Three Hundred Thirty-Five");
 
 			// test a bunch of whole numbers for exceptions
 			for (decimal i = 0; i < 1000000; i += 13)

--- a/Tools/Towel_Testing/Extensions.cs
+++ b/Tools/Towel_Testing/Extensions.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using Towel;
 using Towel.DataStructures;
 
@@ -13,6 +15,9 @@ namespace Towel_Testing
 		{
 			Assert.AreEqual("run go swim".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "ran went swam");
 			Assert.AreEqual("quack".Replace(("run", "ran"), ("swim", "swam"), ("go", "went")), "quack");
+
+			IEnumerable<(string, string)> someIEnum = new[] {("run", "ran"), ("swim", "swam"), ("go", "went")};
+			Assert.AreEqual("run go swim".Replace(someIEnum), "ran went swam");
 		}
 
 		public void AssertAreEqualReversed<A, B>(A actual, B expected)
@@ -80,19 +85,19 @@ namespace Towel_Testing
 			{ // test shifting from maxValue
 				int i = 999;
 				TestingRandom random = new TestingRandom(() => i--);
-				ISet<int> set = new SetHashLinked<int>();
+                Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
 				random.NextUnique(5, 0, 1000, j => { Assert.IsFalse(set.Contains(j)); set.Add(j); });
 				Assert.IsTrue(set.Count == 5);
 			}
 			{ // test shifting from 0
 				TestingRandom random = new TestingRandom(() => 0);
-				ISet<int> set = new SetHashLinked<int>();
+                Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
 				random.NextUnique(5, 0, 1000, i => { Assert.IsFalse(set.Contains(i)); set.Add(i); });
 				Assert.IsTrue(set.Count == 5);
 			}
 			{ // test shifting from inner value
 				TestingRandom random = new TestingRandom(() => 7);
-				ISet<int> set = new SetHashLinked<int>();
+                Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
 				random.NextUnique(5, 0, 1000, i => { Assert.IsFalse(set.Contains(i)); set.Add(i); });
 				Assert.IsTrue(set.Count == 5);
 			}
@@ -100,7 +105,7 @@ namespace Towel_Testing
 				Random random = new Random();
 				for (int i = 0; i < 10000; i++)
 				{
-					ISet<int> set = new SetHashLinked<int>();
+                    Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
 					random.NextUnique(5, 0, 1000, j => { Assert.IsFalse(set.Contains(j)); set.Add(j); });
 					Assert.IsTrue(set.Count == 5);
 				}
@@ -121,19 +126,19 @@ namespace Towel_Testing
 			{ // test shifting from maxValue
 				int i = 999;
 				TestingRandom random = new TestingRandom(() => i--);
-				ISet<int> set = new SetHashLinked<int>();
+                Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
 				random.NextUnique(100, 0, 1000, j => { Assert.IsFalse(set.Contains(j)); set.Add(j); });
 				Assert.IsTrue(set.Count == 100);
 			}
 			{ // test shifting from 0
 				TestingRandom random = new TestingRandom(() => 0);
-				ISet<int> set = new SetHashLinked<int>();
+                Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
 				random.NextUnique(100, 0, 1000, i => { Assert.IsFalse(set.Contains(i)); set.Add(i); });
 				Assert.IsTrue(set.Count == 100);
 			}
 			{ // test shifting from inner value
 				TestingRandom random = new TestingRandom(() => 7);
-				ISet<int> set = new SetHashLinked<int>();
+                Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
 				random.NextUnique(100, 0, 1000, i => { Assert.IsFalse(set.Contains(i)); set.Add(i); });
 				Assert.IsTrue(set.Count == 100);
 			}
@@ -141,7 +146,7 @@ namespace Towel_Testing
 				Random random = new Random();
 				for (int i = 0; i < 10000; i++)
 				{
-					ISet<int> set = new SetHashLinked<int>();
+                    Towel.DataStructures.ISet<int> set = new SetHashLinked<int>();
 					random.NextUnique(100, 0, 1000, j => { Assert.IsFalse(set.Contains(j)); set.Add(j); });
 					Assert.IsTrue(set.Count == 100);
 				}


### PR DESCRIPTION
It's a feature proposal. Instead of
```cs
myString.Replace("run", "ran").Replace("swim", "swam").Replace("go", "went")
```

We would write

```cs
myString.Replace(("run", "ran"), ("swim", "swam"), ("go", "went"))
```

No more loops like that:
```cs
foreach (var rule in rules)
    myString = myString.Replace(rule.old, rule.new);
```

Instead, we could write
```cs
myString = myString.Replace(myRules.Select(c => (c.old, c.new)));
```

Or, if our array/IEnumerable perfectly matches the argument,
```cs
myString = myString.Replace(rules);
```

If you accept features, you may Squash and merge so that commits do not flood your master