### PR TITLE
There are identical sub-expressions

### DIFF
--- a/Sources/Towel/CommandLine.cs
+++ b/Sources/Towel/CommandLine.cs
@@ -82,7 +82,7 @@ namespace Towel
 			for (int i = 1; i < args.Length; i += 2)
 			{
 				string arg = args[i];
-				if (arg.Length < 3 || arg[0] != '-' || arg[0] != '-')
+				if (arg.Length < 3 || arg[0] != '-')
 				{
 					Console.Error.WriteLine($"Invalid parameter {arg} in index {i}.");
 					return;


### PR DESCRIPTION


**Description**
_Removed  identical sub-expression ` arg[0] != '-'`_

**Issues**
#76
