### PR TITLE
Zip added

### DIFF
--- a/Sources/Towel/Statics-SequenceAnalysis.cs
+++ b/Sources/Towel/Statics-SequenceAnalysis.cs
@@ -1515,5 +1515,35 @@ namespace Towel
 		}
 
 		#endregion
+			
+		#region Multiple sequences	
+		/// <summary>
+		/// Similar to python's zip. Sequentially iterates over a pair of sequences, producing
+		/// a tuple of elements from each of the sequences one by one
+		/// </summary>
+		/// <typeparam name="T1">
+		/// A type, contained by the first sequence
+		/// </typeparam>
+		/// <typeparam name="T2">
+		/// A type, contained by the second sequence
+		/// </typeparam>
+		/// <param name="seq">
+		/// It is your tuple of sequences. You would normally use it as
+		/// (oneSequence, anotherSequence).Zip()
+		/// </param>
+		/// <returns>
+		/// An iteratable <see cref="IEnumerable>"/> of a tuple of <typeparamref name="T1"/> and <typeparamref name="T2"/>
+		/// </returns>
+		public static IEnumerable<(T1 left, T2 right)> Zip<T1, T2>(this (IEnumerable<T1> l, IEnumerable<T2> r) seq)
+		{
+			bool l, r;
+			var enumL = seq.l.GetEnumerator();
+			var enumR = seq.r.GetEnumerator();
+			while ((l = enumL.MoveNext()) & (r = enumR.MoveNext()))
+				yield return (enumL.Current, enumR.Current);
+			if (l != r)
+				throw new Exception(); // TODO: what should be here?
+		}
+		#endregion
 	}
 }

--- a/Sources/Towel/Statics-SequenceAnalysis.cs
+++ b/Sources/Towel/Statics-SequenceAnalysis.cs
@@ -1534,7 +1534,7 @@ namespace Towel
 		/// <returns>
 		/// An iteratable <see cref="IEnumerable>"/> of a tuple of <typeparamref name="T1"/> and <typeparamref name="T2"/>
 		/// </returns>
-		public static IEnumerable<(T1 left, T2 right)> Zip<T1, T2>(this (IEnumerable<T1> l, IEnumerable<T2> r) seq)
+		public static System.Collections.Generic.IEnumerable<(T1 left, T2 right)> Zip<T1, T2>(this (System.Collections.Generic.IEnumerable<T1> l, System.Collections.Generic.IEnumerable<T2> r) seq)
 		{
 			bool l, r;
 			var enumL = seq.l.GetEnumerator();

--- a/Sources/Towel/Statics-SequenceAnalysis.cs
+++ b/Sources/Towel/Statics-SequenceAnalysis.cs
@@ -1515,35 +1515,30 @@ namespace Towel
 		}
 
 		#endregion
-			
-		#region Multiple sequences	
-		/// <summary>
-		/// Similar to python's zip. Sequentially iterates over a pair of sequences, producing
-		/// a tuple of elements from each of the sequences one by one
-		/// </summary>
-		/// <typeparam name="T1">
-		/// A type, contained by the first sequence
-		/// </typeparam>
-		/// <typeparam name="T2">
-		/// A type, contained by the second sequence
-		/// </typeparam>
-		/// <param name="seq">
-		/// It is your tuple of sequences. You would normally use it as
-		/// (oneSequence, anotherSequence).Zip()
-		/// </param>
-		/// <returns>
-		/// An iteratable <see cref="IEnumerable>"/> of a tuple of <typeparamref name="T1"/> and <typeparamref name="T2"/>
-		/// </returns>
-		public static System.Collections.Generic.IEnumerable<(T1 left, T2 right)> Zip<T1, T2>(this (System.Collections.Generic.IEnumerable<T1> l, System.Collections.Generic.IEnumerable<T2> r) seq)
+
+		#region Zip
+
+		/// <summary>Combines two <see cref="System.Collections.Generic.IEnumerable{T}"/>'s into a single <see cref="System.Collections.Generic.IEnumerable{T}"/> of <see cref="ValueTuple{T1, T2}"/>'s of the values of both <paramref name="a"/> and <paramref name="b"/>.</summary>
+		/// <typeparam name="T1">The generic type of the first sequence.</typeparam>
+		/// <typeparam name="T2">The generic type of the second sequence.</typeparam>
+		/// <param name="a">The first sequence of the zip.</param>
+		/// <param name="b">The second sequence of the zip.</param>
+		/// <returns>An <see cref="System.Collections.Generic.IEnumerable{T}"/> of <see cref="ValueTuple{T1, T2}"/>'s containing the values of <paramref name="a"/> and <paramref name="b"/>.</returns>
+		/// <exception cref="ArgumentException">Thrown when </exception>
+		public static System.Collections.Generic.IEnumerable<(T1 A, T2 B)> Zip<T1, T2>(System.Collections.Generic.IEnumerable<T1> a, System.Collections.Generic.IEnumerable<T2> b)
 		{
-			bool l, r;
-			var enumL = seq.l.GetEnumerator();
-			var enumR = seq.r.GetEnumerator();
-			while ((l = enumL.MoveNext()) & (r = enumR.MoveNext()))
-				yield return (enumL.Current, enumR.Current);
-			if (l != r)
-				throw new Exception(); // TODO: what should be here?
+			if (a is null) throw new ArgumentNullException(nameof(a));
+			if (b is null) throw new ArgumentNullException(nameof(b));
+			var (ea, eb) = (a.GetEnumerator(), b.GetEnumerator());
+			Loop:
+			switch (ea.MoveNext(), eb.MoveNext())
+			{
+				case (true, true): yield return (ea.Current, eb.Current); goto Loop;
+				case (false, false): break;
+				default: throw new ArgumentException($"!({nameof(a)}.Count() != {nameof(b)}.Count())");
+			}
 		}
+
 		#endregion
 	}
 }

--- a/Sources/Towel/Towel.xml
+++ b/Sources/Towel/Towel.xml
@@ -30966,6 +30966,15 @@
             <param name="predicate">The value to look for.</param>
             <returns>True if a predicated was found.</returns>
         </member>
+        <member name="M:Towel.Statics.Zip``2(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1})">
+            <summary>Combines two <see cref="T:System.Collections.Generic.IEnumerable`1"/>'s into a single <see cref="T:System.Collections.Generic.IEnumerable`1"/> of <see cref="T:System.ValueTuple`2"/>'s of the values of both <paramref name="a"/> and <paramref name="b"/>.</summary>
+            <typeparam name="T1">The generic type of the first sequence.</typeparam>
+            <typeparam name="T2">The generic type of the second sequence.</typeparam>
+            <param name="a">The first sequence of the zip.</param>
+            <param name="b">The second sequence of the zip.</param>
+            <returns>An <see cref="T:System.Collections.Generic.IEnumerable`1"/> of <see cref="T:System.ValueTuple`2"/>'s containing the values of <paramref name="a"/> and <paramref name="b"/>.</returns>
+            <exception cref="T:System.ArgumentException">Thrown when </exception>
+        </member>
         <member name="M:Towel.Statics.Shuffle_XML">
             <summary>
             Sorts values into a randomized order.

--- a/Tools/Towel_Testing/Statics.cs
+++ b/Tools/Towel_Testing/Statics.cs
@@ -5,6 +5,7 @@ using static Towel.Statics;
 using Towel.Measurements;
 using Towel.DataStructures;
 using System.Runtime.CompilerServices;
+using System.Linq;
 
 namespace Towel_Testing
 {
@@ -2483,6 +2484,33 @@ namespace Towel_Testing
 			Assert.ThrowsException<ArgumentOutOfRangeException>(() => NextUniquePoolTracking<FuncRuntime<int, int, int>>(-1, 0, 1, new Func<int, int, int>((_, _) => default)));
 			Assert.ThrowsException<ArgumentOutOfRangeException>(() => NextUniquePoolTracking<FuncRuntime<int, int, int>>(1, 0, -1, new Func<int, int, int>((_, _) => default)));
 			Assert.ThrowsException<ArgumentOutOfRangeException>(() => NextUniquePoolTracking<FuncRuntime<int, int, int>>(2, 0, 1, new Func<int, int, int>((_, _) => default)));
+		}
+
+		#endregion
+
+		#region Zip
+
+		[TestMethod] public void Zip_Testing()
+		{
+			{
+				int[] a = { 1, 2, 3 };
+				string[] b = { "one", "two", "three" };
+				(int, string)[] c = { (a[0], b[0]), (a[1], b[1]), (a[2], b[2]) };
+				Assert.IsTrue(Zip(a, b).SequenceEqual(c));
+				Assert.ThrowsException<ArgumentNullException>(() => Zip(default(int[]), b).ToList());
+				Assert.ThrowsException<ArgumentNullException>(() => Zip(a, default(string[])).ToList());
+				Assert.ThrowsException<ArgumentNullException>(() => Zip(default(int[]), default(string[])).ToList());
+			}
+			{
+				int[] a = { 1, 2 };
+				string[] b = { "one", "two", "three" };
+				Assert.ThrowsException<ArgumentException>(() => Zip(a, b).ToList());
+			}
+			{
+				int[] a = { 1, 2, 3 };
+				string[] b = { "one", "two" };
+				Assert.ThrowsException<ArgumentException>(() => Zip(a, b).ToList());
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
To be discussed. For now I added a naive and short implementation, showing the general idea of the method.

[Here](https://paste.mod.gg/onahawugep.php) you can find a more complicated solution, which takes into account, that some IEnumerables might be arrays, and don't need creating of an IEnumerator, which is costly by itself. It uses structs as wrappers, providing zero cost at addressing the enumerators and arrays. However, since the `Zip` method still returns an `IEnumerable`, iterating over it is still costly.