### PR TITLE
Disposing enumerator

### DIFF
--- a/Sources/Towel/Statics-SequenceAnalysis.cs
+++ b/Sources/Towel/Statics-SequenceAnalysis.cs
@@ -1082,7 +1082,7 @@ namespace Towel
 		public static bool IsOrdered<T, TCompare>(this System.Collections.Generic.IEnumerable<T> enumerable, TCompare compare = default)
 			where TCompare : struct, IFunc<T, T, CompareResult>
 		{
-			System.Collections.Generic.IEnumerator<T> enumerator = enumerable.GetEnumerator();
+			using System.Collections.Generic.IEnumerator<T> enumerator = enumerable.GetEnumerator();
 			T previous = enumerator.Current;
 			while (enumerator.MoveNext())
 			{


### PR DESCRIPTION
This is funny because I discovered this bug in my own code, and then assumed that you would have the same bug... and it seems like I'm not wrong 😆 . I'm not sure it's the only place where you create a enumerator, but I cannot fix them at the moment, so it's more of a bug report than actual PR